### PR TITLE
fix(infra): resolve Terraform validation and tfcmt permission errors

### DIFF
--- a/.github/workflows/infra_apply.yml
+++ b/.github/workflows/infra_apply.yml
@@ -9,8 +9,9 @@ on:
       - '.github/workflows/infra_apply.yml'
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
+  issues: write
 
 concurrency:
   group: terraform-apply-cloudflare

--- a/.github/workflows/infra_plan.yml
+++ b/.github/workflows/infra_plan.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   terraform-plan:

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -45,13 +45,13 @@ resource "cloudflare_pages_domain" "site" {
   count        = local.site_domain != null ? 1 : 0
   account_id   = var.account_id
   project_name = cloudflare_pages_project.site.name
-  name         = local.site_domain
+  name         = coalesce(local.site_domain, "placeholder.invalid")
 }
 
 resource "cloudflare_dns_record" "site" {
   count   = local.site_domain != null && local.zone_id != null ? 1 : 0
-  zone_id = local.zone_id
-  name    = local.site_domain
+  zone_id = coalesce(local.zone_id, "placeholder")
+  name    = coalesce(local.site_domain, "placeholder.invalid")
   type    = "CNAME"
   content = "${cloudflare_pages_project.site.name}.pages.dev"
   proxied = true
@@ -63,7 +63,7 @@ resource "cloudflare_r2_custom_domain" "images" {
   count       = local.images_domain != null && local.zone_id != null ? 1 : 0
   account_id  = var.account_id
   bucket_name = cloudflare_r2_bucket.images.name
-  domain      = local.images_domain
-  zone_id     = local.zone_id
+  domain      = coalesce(local.images_domain, "placeholder.invalid")
+  zone_id     = coalesce(local.zone_id, "placeholder")
   enabled     = true
 }


### PR DESCRIPTION
## Summary
- `infra/main.tf`: Cloudflare プロバイダが `count = 0` でも必須属性を検証するため、`site_domain` / `zone_id` / `images_domain` が null のときに発生していた `Missing Configuration for Required Attribute` エラーを、`coalesce()` でプレースホルダ値を渡す形で修正
- `.github/workflows/infra_apply.yml`: push イベントで tfcmt がコミットコメント API を叩くのに必要な `contents: write` を付与
- `.github/workflows/*.yml`: PR コメントは issues API 経由のため、両ワークフローに `issues: write` を追加

## Test plan
- [ ] このPRを開き、`Infra Plan` ワークフローが正常に完了すること（terraform validate/plan が通り、tfcmt がPRにコメントすること）
- [ ] マージ後、`Infra Apply` ワークフローが成功し、tfcmt がコミットコメントを投稿できること
- [ ] 既存リソース（`cloudflare_pages_project.site`, `cloudflare_r2_bucket.images`）に対して drift が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)