### PR TITLE
fix(infra): pass null instead of empty map for Pages env_vars

### DIFF
--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -15,4 +15,13 @@ locals {
   # Pages Functions runtime
   compatibility_date  = "2025-09-01"
   compatibility_flags = ["nodejs_compat"]
+
+  production_env_vars = merge(
+    local.images_domain != null ? {
+      PUBLIC_R2_BASE = { type = "plain_text", value = "https://${local.images_domain}" }
+    } : {},
+    local.site_domain != null ? {
+      SITE_URL = { type = "plain_text", value = "https://${local.site_domain}" }
+    } : {},
+  )
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -13,14 +13,7 @@ resource "cloudflare_pages_project" "site" {
     production = {
       compatibility_date  = local.compatibility_date
       compatibility_flags = local.compatibility_flags
-      env_vars = merge(
-        local.images_domain != null ? {
-          PUBLIC_R2_BASE = { type = "plain_text", value = "https://${local.images_domain}" }
-        } : {},
-        local.site_domain != null ? {
-          SITE_URL = { type = "plain_text", value = "https://${local.site_domain}" }
-        } : {},
-      )
+      env_vars            = length(local.production_env_vars) > 0 ? local.production_env_vars : null
     }
     preview = {
       compatibility_date  = local.compatibility_date


### PR DESCRIPTION
## Summary
- Cloudflare プロバイダは空の `env_vars = {}` を apply 後に `null` として返すため、"Provider produced inconsistent result after apply" エラーで `cloudflare_pages_project.site` の作成が失敗していた
- `production_env_vars` を `locals.tf` に抽出し、空なら `null` を渡す形に変更して plan と apply の整合性を確保

## Test plan
- [ ] `Infra Plan` が通り、`env_vars` が `null` として表示されること
- [ ] `Infra Apply` で inconsistent result エラーなしに Pages プロジェクトが作成されること
- [ ] 以降の plan で `env_vars` に drift が発生しないこと

## Note
前回の apply で Cloudflare 側に作成された Pages project / R2 bucket はユーザーが手動削除済み。state もクリーンな想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)