### PR TITLE
feat(infra): manage R2 r2.dev public access in Terraform

### DIFF
--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -16,10 +16,18 @@ locals {
   compatibility_date  = "2025-09-01"
   compatibility_flags = ["nodejs_compat"]
 
+  # Public base URL for handbook images. Prefers a custom domain when
+  # configured, otherwise falls back to the bucket's managed r2.dev subdomain.
+  images_base_url = (
+    local.images_domain != null
+    ? "https://${local.images_domain}"
+    : "https://${cloudflare_r2_managed_domain.images.domain}"
+  )
+
   production_env_vars = merge(
-    local.images_domain != null ? {
-      PUBLIC_R2_BASE = { type = "plain_text", value = "https://${local.images_domain}" }
-    } : {},
+    {
+      PUBLIC_R2_BASE = { type = "plain_text", value = local.images_base_url }
+    },
     local.site_domain != null ? {
       SITE_URL = { type = "plain_text", value = "https://${local.site_domain}" }
     } : {},

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -31,6 +31,16 @@ resource "cloudflare_r2_bucket" "images" {
   location   = local.r2_location
 }
 
+# Enables the bucket's managed `pub-<accountid>.r2.dev` subdomain so the site
+# can serve handbook images from R2. Cloudflare rate-limits r2.dev access and
+# documents it for development use, but it is acceptable for low-traffic
+# launches; flip `images_domain` later to shift to a custom domain.
+resource "cloudflare_r2_managed_domain" "images" {
+  account_id  = var.account_id
+  bucket_name = cloudflare_r2_bucket.images.name
+  enabled     = true
+}
+
 # -----------------------------------------------------------------------------
 # Custom domains (optional — only created when the locals are set)
 # -----------------------------------------------------------------------------

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -19,6 +19,6 @@ output "r2_bucket_name" {
 }
 
 output "images_base_url" {
-  value       = local.images_domain != null ? "https://${local.images_domain}" : null
-  description = "Public base URL for R2 images (null until images_domain is set)."
+  value       = local.images_base_url
+  description = "Public base URL for R2 images. Custom domain when set, otherwise the bucket's managed r2.dev subdomain. Feed into the GitHub Actions `PUBLIC_R2_BASE` repo variable."
 }


### PR DESCRIPTION
## Summary

- Adds `cloudflare_r2_managed_domain.images` so the bucket's `pub-<accountid>.r2.dev` public access stops being a dashboard-only step.
- Computes `images_base_url` once — custom domain when `images_domain` is wired, otherwise the managed r2.dev subdomain — and feeds it into the Pages production `env_vars` (`PUBLIC_R2_BASE`) and the `images_base_url` Terraform output.
- Switching to a real custom domain later is just `locals.tf` + `terraform apply`; the rest auto-updates.

## Test plan

- [ ] `terraform plan` shows only `cloudflare_r2_managed_domain.images` create + Pages `env_vars` adding `PUBLIC_R2_BASE`.
- [ ] `terraform apply` succeeds.
- [ ] `terraform output images_base_url` returns `https://pub-<accountid>.r2.dev`.
- [ ] The URL is reachable (returns 401 on root for an unconfigured listing, 200 once an object is uploaded).
- [ ] After feeding the URL into the GHA `PUBLIC_R2_BASE` repo variable, a build emits handbook image `<img src>` pointing at the R2 URL (verified once `npm run upload:images` lands referenced images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)