### PR TITLE
fix(deploy): fall back when SITE_URL/PUBLIC_R2_BASE are empty strings

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,13 +7,16 @@ import { rewriteAssetPaths } from './src/plugins/rewrite-asset-paths.mjs';
 import { headingIds } from './src/plugins/heading-ids.mjs';
 
 // NOTE: Replace with the final production URL before launch.
-const SITE = process.env.SITE_URL ?? 'https://gitlab-handbook-ja.pages.dev';
+// `||` (not `??`) — GitHub Actions injects unset `vars.*` as empty strings,
+// not undefined, so `??` would not fall back and Astro would reject the
+// empty string with "Invalid URL".
+const SITE = process.env.SITE_URL || 'https://gitlab-handbook-ja.pages.dev';
 const UPSTREAM_BASE = 'https://handbook.gitlab.com';
 // Asset host for absolute paths inside Markdown (`/images/...` etc.). In prod
 // builds set PUBLIC_R2_BASE to the R2 public URL (e.g. https://pub-xxx.r2.dev).
-// When unset, fall back to the upstream handbook so local dev keeps working
-// without an R2 bucket.
-const ASSET_BASE = process.env.PUBLIC_R2_BASE ?? UPSTREAM_BASE;
+// When unset (or empty), fall back to the upstream handbook so local dev
+// keeps working without an R2 bucket.
+const ASSET_BASE = process.env.PUBLIC_R2_BASE || UPSTREAM_BASE;
 
 export default defineConfig({
   site: SITE,


### PR DESCRIPTION
## Summary

Post-merge deploy on `main` failed with:

```
[config] Astro found issue(s) with your configuration:

! Invalid URL
```

`app_deploy.yml` injects `SITE_URL: ${{ vars.SITE_URL }}` into the build env. When `vars.SITE_URL` is not set on the repo, GitHub Actions passes it through as an empty string, so `process.env.SITE_URL ?? '<fallback>'` resolves to `""` and Astro rejects `site: ""`.

Switch both `SITE_URL` and `PUBLIC_R2_BASE` reads to `||` so empty strings fall back to the defaults the same way unset values do.

## Test plan

- [x] Reproduced locally: `SITE_URL='' PUBLIC_R2_BASE='https://pub-…' npm run build` → "Invalid URL" before, builds 11 pages after.
- [ ] Post-merge `app_deploy.yml` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)