### PR TITLE
feat(infra): wire custom domain gl-handbook-ja.page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,11 +6,10 @@ import tailwind from '@astrojs/tailwind';
 import { rewriteAssetPaths } from './src/plugins/rewrite-asset-paths.mjs';
 import { headingIds } from './src/plugins/heading-ids.mjs';
 
-// NOTE: Replace with the final production URL before launch.
 // `||` (not `??`) — GitHub Actions injects unset `vars.*` as empty strings,
 // not undefined, so `??` would not fall back and Astro would reject the
 // empty string with "Invalid URL".
-const SITE = process.env.SITE_URL || 'https://gitlab-handbook-ja.pages.dev';
+const SITE = process.env.SITE_URL || 'https://gl-handbook-ja.page';
 const UPSTREAM_BASE = 'https://handbook.gitlab.com';
 // Asset host for absolute paths inside Markdown (`/images/...` etc.). In prod
 // builds set PUBLIC_R2_BASE to the R2 public URL (e.g. https://pub-xxx.r2.dev).

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -6,10 +6,10 @@ locals {
   # Allowed: apac, eeur, enam, weur, wnam, oc. Null for automatic.
   r2_location = "apac"
 
-  # Custom domain settings — leave all three null to skip custom domain wiring
+  # Custom domain settings — leave them null to skip custom domain wiring
   # and only use the default *.pages.dev URL.
-  zone_id       = null
-  site_domain   = null
+  zone_id       = "975c43daab7967831b8cd29d07830937"
+  site_domain   = "gl-handbook-ja.page"
   images_domain = null
 
   # Pages Functions runtime


### PR DESCRIPTION
## Summary

Activates the custom domain `gl-handbook-ja.page` (Cloudflare-managed zone). The existing `cloudflare_pages_domain.site` and `cloudflare_dns_record.site` resources were already gated on `site_domain` / `zone_id` being non-null, so populating the locals is enough.

After apply:
- `cloudflare_pages_domain.site` attaches `gl-handbook-ja.page` to the Pages project.
- `cloudflare_dns_record.site` adds a proxied CNAME to `gitlab-handbook-ja.pages.dev`.
- `production_env_vars.SITE_URL` flips to `https://gl-handbook-ja.page`.

`astro.config.mjs` default also moved to the new origin so local builds emit correct sitemap/canonical URLs without needing `SITE_URL` in env.

The Pages project name stays `gitlab-handbook-ja` (so the *.pages.dev URL keeps working).

## Manual follow-up

- Update GitHub Actions repo variable `SITE_URL` → `https://gl-handbook-ja.page`. (Pages env_vars are wired but `app_deploy.yml` reads `vars.SITE_URL` at build time for direct-upload.)
- After first deploy on the new domain: verify HTTPS cert provisions (Cloudflare auto), `gl-handbook-ja.page` resolves, and the `pages.dev` URL still serves (so old links don't 404).

## Test plan

- [x] `terraform validate` passes.
- [ ] `terraform plan` shows: 1 added (`cloudflare_pages_domain.site`), 1 added (`cloudflare_dns_record.site`), 1 in-place update (Pages env_vars).
- [ ] After apply, https://gl-handbook-ja.page/ serves the site.
- [ ] https://gitlab-handbook-ja.pages.dev/ still serves (project unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)