### PR TITLE
feat(infra): bulk-redirect *.pages.dev to the custom domain

### DIFF
--- a/infra/redirect-pages-dev.tf
+++ b/infra/redirect-pages-dev.tf
@@ -1,0 +1,55 @@
+# -----------------------------------------------------------------------------
+# Account-level Bulk Redirect: 301 every request to the Pages project's
+# default `*.pages.dev` URL over to the canonical custom domain. Cloudflare
+# Pages cannot fully disable that subdomain (per their docs), so this rule
+# is the supported workaround for keeping the canonical URL clean and
+# avoiding handing out a `gitlab-handbook-ja.pages.dev` link that visitors
+# would actually load.
+# -----------------------------------------------------------------------------
+resource "cloudflare_list" "redirect_pages_dev" {
+  account_id  = var.account_id
+  name        = "redirect_pages_dev"
+  kind        = "redirect"
+  description = "Bulk redirect entries for *.pages.dev → custom domain."
+}
+
+resource "cloudflare_list_item" "redirect_pages_dev_root" {
+  account_id = var.account_id
+  list_id    = cloudflare_list.redirect_pages_dev.id
+
+  redirect = {
+    source_url            = "${cloudflare_pages_project.site.subdomain}/"
+    target_url            = "https://${local.site_domain}/"
+    status_code           = 301
+    include_subdomains    = false
+    subpath_matching      = true
+    preserve_query_string = true
+    preserve_path_suffix  = true
+  }
+}
+
+# Account-level redirect ruleset (root). There is only one root ruleset per
+# phase per account, so any future Bulk Redirect lists must be added as
+# additional rules on this same ruleset.
+resource "cloudflare_ruleset" "redirect_pages_dev" {
+  account_id  = var.account_id
+  name        = "default"
+  description = "Bulk Redirects ruleset"
+  kind        = "root"
+  phase       = "http_request_redirect"
+
+  rules = [
+    {
+      action      = "redirect"
+      description = "Redirect *.pages.dev to the custom domain."
+      enabled     = true
+      expression  = format("http.request.full_uri in $%s", cloudflare_list.redirect_pages_dev.name)
+      action_parameters = {
+        from_list = {
+          name = cloudflare_list.redirect_pages_dev.name
+          key  = "http.request.full_uri"
+        }
+      }
+    },
+  ]
+}


### PR DESCRIPTION
## Summary

Cloudflare Pages cannot disable the project's default `*.pages.dev` subdomain ([known issue](https://developers.cloudflare.com/pages/platform/known-issues/)), so add an account-level Bulk Redirect that 301s every request from `gitlab-handbook-ja.pages.dev/*` to `https://gl-handbook-ja.page/*`.

This keeps the canonical URL clean and avoids serving the GitLab-trademarked hostname as live content while preserving inbound links via the redirect (SEO + compatibility).

## Implementation

Standard Cloudflare Bulk Redirect trio in [infra/redirect-pages-dev.tf](infra/redirect-pages-dev.tf):

- `cloudflare_list` (`kind = "redirect"`) holding redirect entries.
- `cloudflare_list_item` defining source/target with `subpath_matching`, `preserve_query_string`, `preserve_path_suffix` all enabled (so `/handbook/values/?foo=bar` correctly maps to `https://gl-handbook-ja.page/handbook/values/?foo=bar`).
- `cloudflare_ruleset` at the account root (`phase = "http_request_redirect"`, `kind = "root"`) referencing the list via `from_list`.

> ⚠️ Cloudflare allows only one root ruleset per phase per account. Any future Bulk Redirect lists must be added as additional rules on this ruleset, not in a new one.

## Test plan

- [x] `terraform validate` passes locally.
- [ ] `terraform plan` shows: list + 1 list_item + ruleset (3 created).
- [ ] After apply: `curl -I https://gitlab-handbook-ja.pages.dev/handbook/values/` returns `301` to `https://gl-handbook-ja.page/handbook/values/`.
- [ ] `curl -I https://gitlab-handbook-ja.pages.dev/?q=foo` preserves query string after redirect.
- [ ] `https://gl-handbook-ja.page/` continues to serve directly (not affected by the redirect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)