### PR TITLE
fix: show mobile nav button on homepage

### DIFF
--- a/src/components/MobileNav.astro
+++ b/src/components/MobileNav.astro
@@ -1,0 +1,84 @@
+---
+import Sidebar from '~/components/Sidebar.astro';
+
+interface Props {
+  /** Breakpoint at and above which the drawer/button is hidden (sidebar takes over). */
+  hiddenFrom?: 'md' | 'lg';
+}
+
+const { hiddenFrom = 'md' } = Astro.props;
+// Static class strings so Tailwind JIT can discover them.
+const hiddenClass = hiddenFrom === 'lg' ? 'lg:hidden' : 'md:hidden';
+---
+<div
+  id="mobile-nav-overlay"
+  class={`hidden fixed inset-0 z-[60] ${hiddenClass}`}
+  role="dialog"
+  aria-modal="true"
+  aria-label="ナビゲーション"
+>
+  <div id="mobile-nav-backdrop" class="absolute inset-0 bg-black/50"></div>
+  <aside class="absolute inset-y-0 left-0 w-72 max-w-[85vw] bg-white shadow-2xl flex flex-col">
+    <div class="flex items-center justify-between px-4 py-3 border-b border-gray-200 shrink-0">
+      <span class="font-semibold text-gray-900 text-sm">ナビゲーション</span>
+      <button
+        id="mobile-nav-close"
+        class="p-1.5 rounded hover:bg-gray-100 text-gray-600 focus:outline-none focus:ring-2 focus:ring-accent-500"
+        aria-label="閉じる"
+      >
+        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path d="M6 18L18 6M6 6l12 12" stroke-linecap="round" />
+        </svg>
+      </button>
+    </div>
+    <div class="overflow-y-auto flex-1 px-4 py-3">
+      <Sidebar />
+    </div>
+  </aside>
+</div>
+
+<div class={`fixed bottom-5 right-5 z-30 ${hiddenClass}`}>
+  <button
+    id="mobile-nav-open"
+    class="flex items-center gap-2 bg-accent-700 text-white rounded-full shadow-lg px-4 py-2.5 text-sm font-medium hover:bg-accent-600 active:scale-95 transition-transform focus:outline-none focus:ring-2 focus:ring-accent-500 focus:ring-offset-2"
+    aria-label="ナビゲーションを開く"
+    aria-expanded="false"
+    aria-controls="mobile-nav-overlay"
+  >
+    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+      <path d="M3 6h18M3 12h18M3 18h18" stroke-linecap="round" />
+    </svg>
+    ナビ
+  </button>
+</div>
+
+<script>
+  const overlay = document.getElementById('mobile-nav-overlay');
+  const openBtn = document.getElementById('mobile-nav-open');
+  const closeBtn = document.getElementById('mobile-nav-close');
+  const backdrop = document.getElementById('mobile-nav-backdrop');
+
+  function openNav() {
+    overlay?.classList.remove('hidden');
+    openBtn?.setAttribute('aria-expanded', 'true');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeNav() {
+    overlay?.classList.add('hidden');
+    openBtn?.setAttribute('aria-expanded', 'false');
+    document.body.style.overflow = '';
+  }
+
+  openBtn?.addEventListener('click', openNav);
+  closeBtn?.addEventListener('click', closeNav);
+  backdrop?.addEventListener('click', closeNav);
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') closeNav();
+  });
+
+  overlay?.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', closeNav);
+  });
+</script>

--- a/src/pages/handbook/[...slug].astro
+++ b/src/pages/handbook/[...slug].astro
@@ -2,6 +2,7 @@
 import BaseLayout from '~/layouts/BaseLayout.astro';
 import StaleBanner from '~/components/StaleBanner.astro';
 import Sidebar from '~/components/Sidebar.astro';
+import MobileNav from '~/components/MobileNav.astro';
 import Toc from '~/components/Toc.astro';
 import Breadcrumbs from '~/components/Breadcrumbs.astro';
 import { getCollection, render, type CollectionEntry } from 'astro:content';
@@ -30,49 +31,7 @@ const upstreamUrl = new URL(page.data.upstream_path, upstreamBase).toString();
   upstreamPath={page.data.upstream_path}
   wide
 >
-  <!-- Mobile sidebar drawer (hidden on md+) -->
-  <div
-    id="mobile-nav-overlay"
-    class="hidden fixed inset-0 z-[60]"
-    role="dialog"
-    aria-modal="true"
-    aria-label="ナビゲーション"
-  >
-    <div id="mobile-nav-backdrop" class="absolute inset-0 bg-black/50"></div>
-    <aside class="absolute inset-y-0 left-0 w-72 max-w-[85vw] bg-white shadow-2xl flex flex-col">
-      <div class="flex items-center justify-between px-4 py-3 border-b border-gray-200 shrink-0">
-        <span class="font-semibold text-gray-900 text-sm">ナビゲーション</span>
-        <button
-          id="mobile-nav-close"
-          class="p-1.5 rounded hover:bg-gray-100 text-gray-600 focus:outline-none focus:ring-2 focus:ring-accent-500"
-          aria-label="閉じる"
-        >
-          <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-            <path d="M6 18L18 6M6 6l12 12" stroke-linecap="round" />
-          </svg>
-        </button>
-      </div>
-      <div class="overflow-y-auto flex-1 px-4 py-3">
-        <Sidebar />
-      </div>
-    </aside>
-  </div>
-
-  <!-- Floating nav button (mobile only, hidden on md+) -->
-  <div class="fixed bottom-5 right-5 z-30 md:hidden">
-    <button
-      id="mobile-nav-open"
-      class="flex items-center gap-2 bg-accent-700 text-white rounded-full shadow-lg px-4 py-2.5 text-sm font-medium hover:bg-accent-600 active:scale-95 transition-transform focus:outline-none focus:ring-2 focus:ring-accent-500 focus:ring-offset-2"
-      aria-label="ナビゲーションを開く"
-      aria-expanded="false"
-      aria-controls="mobile-nav-overlay"
-    >
-      <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-        <path d="M3 6h18M3 12h18M3 18h18" stroke-linecap="round" />
-      </svg>
-      ナビ
-    </button>
-  </div>
+  <MobileNav hiddenFrom="md" />
 
   <div class="md:grid md:grid-cols-[18rem_minmax(0,1fr)] md:gap-8 xl:grid-cols-[18rem_minmax(0,1fr)_20rem]">
     <div class="hidden md:block md:sticky md:top-4 md:self-start md:max-h-[calc(100vh-2rem)] md:overflow-y-auto md:pr-2">
@@ -99,35 +58,4 @@ const upstreamUrl = new URL(page.data.upstream_path, upstreamBase).toString();
     </div>
   </div>
 
-  <script>
-    const overlay = document.getElementById('mobile-nav-overlay');
-    const openBtn = document.getElementById('mobile-nav-open');
-    const closeBtn = document.getElementById('mobile-nav-close');
-    const backdrop = document.getElementById('mobile-nav-backdrop');
-
-    function openNav() {
-      overlay?.classList.remove('hidden');
-      openBtn?.setAttribute('aria-expanded', 'true');
-      document.body.style.overflow = 'hidden';
-    }
-
-    function closeNav() {
-      overlay?.classList.add('hidden');
-      openBtn?.setAttribute('aria-expanded', 'false');
-      document.body.style.overflow = '';
-    }
-
-    openBtn?.addEventListener('click', openNav);
-    closeBtn?.addEventListener('click', closeNav);
-    backdrop?.addEventListener('click', closeNav);
-
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape') closeNav();
-    });
-
-    // Close drawer when navigating (links inside the overlay)
-    overlay?.querySelectorAll('a').forEach(link => {
-      link.addEventListener('click', closeNav);
-    });
-  </script>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '~/layouts/BaseLayout.astro';
 import Sidebar from '~/components/Sidebar.astro';
+import MobileNav from '~/components/MobileNav.astro';
 import { getCollection } from 'astro:content';
 
 const pages = await getCollection('handbook');
@@ -15,6 +16,8 @@ function toSlug(id: string): string {
   description="GitLab Handbook のコミュニティによる非公式日本語訳。AI による機械翻訳を基にしています。"
   wide
 >
+  <MobileNav hiddenFrom="lg" />
+
   <div class="lg:grid lg:grid-cols-[14rem_minmax(0,1fr)] lg:gap-10">
     <div class="hidden lg:block lg:sticky lg:top-4 lg:self-start lg:max-h-[calc(100vh-2rem)] lg:overflow-y-auto lg:pr-2">
       <Sidebar />


### PR DESCRIPTION
The floating "ナビ" button and drawer were only declared inline in
[...slug].astro, so the homepage had no way to open navigation on
mobile. Extract the drawer/button/script into a reusable MobileNav
component and use it on both pages with the appropriate breakpoint
(lg for the homepage where the sidebar appears at lg+, md for
handbook pages).

https://claude.ai/code/session_01AfQz1wTCJgqGu8Bu3u3DSv