### PR TITLE
feat: add GA4 tracking tag via PUBLIC_GA4_ID env var

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,10 @@
 /// <reference path="../.astro/types.d.ts" />
+
+interface ImportMetaEnv {
+  readonly PUBLIC_GA4_ID?: string;
+  readonly PUBLIC_R2_BASE?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -31,6 +31,17 @@ const upstreamUrl = upstreamPath ? new URL(upstreamPath, upstreamBase).toString(
     {description && <meta property="og:description" content={description} />}
     <meta property="og:locale" content="ja_JP" />
     <meta name="robots" content="index,follow" />
+    {import.meta.env.PUBLIC_GA4_ID && (
+      <>
+        <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.PUBLIC_GA4_ID}`} />
+        <script is:inline define:vars={{ ga4Id: import.meta.env.PUBLIC_GA4_ID }}>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', ga4Id);
+        </script>
+      </>
+    )}
   </head>
   <body class="min-h-screen flex flex-col">
     <Header />


### PR DESCRIPTION
## Summary

- `BaseLayout.astro` に GA4 タグを追加（`PUBLIC_GA4_ID` 環境変数が設定されている場合のみ挿入）
- `src/env.d.ts` に `PUBLIC_GA4_ID` と `PUBLIC_R2_BASE` の型定義を追加

## Test plan

- [ ] `PUBLIC_GA4_ID` 未設定のローカル dev 環境でタグが挿入されないことを確認
- [ ] 本番デプロイ後、GA4 管理画面でイベントが届いていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)