### PR TITLE
feat: add PUBLIC_GA4_ID to Cloudflare Pages production env vars

### DIFF
--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -27,6 +27,7 @@ locals {
   production_env_vars = merge(
     {
       PUBLIC_R2_BASE = { type = "plain_text", value = local.images_base_url }
+      PUBLIC_GA4_ID  = { type = "plain_text", value = "G-ED5RXHWDV6" }
     },
     local.site_domain != null ? {
       SITE_URL = { type = "plain_text", value = "https://${local.site_domain}" }


### PR DESCRIPTION
## Summary

- `infra/locals.tf` の `production_env_vars` に `PUBLIC_GA4_ID = "G-ED5RXHWDV6"` を追加
- `terraform apply` 後、Cloudflare Pages の本番環境に環境変数が反映される

## Test plan

- [ ] `terraform plan` で `PUBLIC_GA4_ID` が追加されることを確認
- [ ] `terraform apply` 後、Cloudflare Pages ダッシュボードで環境変数を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)