### PR TITLE
feat: add shortcode handlers for design-document-header, details, note, and team-by-*

### DIFF
--- a/.claude/agents/translator.md
+++ b/.claude/agents/translator.md
@@ -53,6 +53,12 @@ model: inherit
 # 書き込み後
 
 1. `npm run transform:shortcodes -- <出力ファイルパス>` を Bash で実行してショートコードを HTML に展開する（smartypants が引用符をいじる前に必ずやる）。実行結果に `Unknown shortcodes:` の警告が出た場合は、未対応のショートコード名を最終レポートに **必ず明記する**（ユーザーが `scripts/shortcodes/` にハンドラーを追加するかどうか判断するため）。勝手にハンドラーを実装しない — そのファイル自身は raw のまま残してよい。
+
+   **`team-by-*` 系ショートコードについて**: `team-by-manager-slug`, `team-by-manager-role`, `team-by-departments` はチームメンバー情報を動的に引くショートコードで、`scripts/shortcodes/upstream-link.ts` の `TEAM_ANCHORS` マップに登録済みのページであれば自動的に原文へのリンクに変換される。新規ページを翻訳して `Unknown shortcodes` にこれらが含まれた場合は、以下の手順でマップに追加すること:
+   1. 翻訳ファイルのショートコード直上の見出し（英語原文）を確認する
+   2. `curl -s "https://handbook.gitlab.com{upstream_path}"` で upstream ページの見出し ID を取得: `grep -oP '<h[1-6][^>]*id="[^"]*"[^>]*>[^<]+'`
+   3. 該当する見出しの `id` 属性値を `TEAM_ANCHORS` に追加（key: `upstream_path`、value: アンカー ID）
+   4. 追加後に `npm run transform:shortcodes` を再実行する
 2. `translation-state/manifest.json` の対応するエントリを更新（または新規追加）:
    - キー: 原文の相対パス（例: `content/handbook/company/mission.md`）
    - 値: `{ path, upstream_sha, translated_at, model: "claude-opus-4-7", input_hash }`。`input_hash` は原文ファイルの SHA-256（`sha256sum upstream/content/handbook/...md` の結果）。

--- a/scripts/shortcodes/design-document-header.ts
+++ b/scripts/shortcodes/design-document-header.ts
@@ -1,0 +1,68 @@
+import { readFile } from 'node:fs/promises';
+import { parse as parseYaml } from 'yaml';
+import type { ShortcodeHandler } from './types.ts';
+
+// Renders the author/coach handles as `@handle` links to gitlab.com.
+function profileLinks(handles: unknown): string {
+  if (!handles) return '';
+  const list = Array.isArray(handles) ? handles : [handles];
+  return list
+    .map((h) => {
+      const handle = String(h).replace(/^@/, '');
+      return `<a href="https://gitlab.com/${handle}" class="text-blue-600 hover:underline">@${handle}</a>`;
+    })
+    .join(', ');
+}
+
+// Renders a label/badge for status or stage names.
+function badge(name: unknown): string {
+  if (!name) return '';
+  return `<span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">${String(name)}</span>`;
+}
+
+async function parseFrontmatter(filePath: string): Promise<Record<string, unknown>> {
+  const raw = await readFile(filePath, 'utf8');
+  const m = /^---\r?\n([\s\S]*?)\r?\n---/.exec(raw);
+  if (!m) return {};
+  return (parseYaml(m[1]) as Record<string, unknown>) ?? {};
+}
+
+// Docsy-GitLab `engineering/design-document-header` shortcode.
+// Renders a disclaimer alert + a metadata table from page frontmatter.
+export const designDocumentHeader: ShortcodeHandler = async (_args, ctx) => {
+  const fm = await parseFrontmatter(ctx.filePath);
+
+  const disclaimer = `\n<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
+このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
+</div>\n`;
+
+  const coaches = fm['coaches'] ?? fm['coach'];
+  const dris = fm['dris'] ?? fm['approvers'];
+
+  const table = `\n<div class="overflow-x-auto my-4">
+<table class="w-full text-sm border-collapse">
+<thead>
+<tr class="bg-gray-100 text-left">
+<th class="px-3 py-2 border border-gray-300">Status</th>
+<th class="px-3 py-2 border border-gray-300">Authors</th>
+<th class="px-3 py-2 border border-gray-300">Coach</th>
+<th class="px-3 py-2 border border-gray-300">DRIs</th>
+<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
+<th class="px-3 py-2 border border-gray-300">Created</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="px-3 py-2 border border-gray-300">${badge(fm['status'])}</td>
+<td class="px-3 py-2 border border-gray-300">${profileLinks(fm['authors'])}</td>
+<td class="px-3 py-2 border border-gray-300">${profileLinks(coaches)}</td>
+<td class="px-3 py-2 border border-gray-300">${profileLinks(dris)}</td>
+<td class="px-3 py-2 border border-gray-300">${badge(fm['owning-stage'])}</td>
+<td class="px-3 py-2 border border-gray-300">${fm['creation-date'] ?? ''}</td>
+</tr>
+</tbody>
+</table>
+</div>\n`;
+
+  return disclaimer + table;
+};

--- a/scripts/shortcodes/details.ts
+++ b/scripts/shortcodes/details.ts
@@ -1,0 +1,11 @@
+import type { PairedShortcodeHandler } from './types.ts';
+import { parseArgs } from './types.ts';
+
+// Docsy-GitLab `details` shortcode: renders a native HTML <details> element.
+// Supports `summary="..."` and `open` named args.
+export const details: PairedShortcodeHandler = (args, inner) => {
+  const { named } = parseArgs(args);
+  const summary = named.summary ?? 'Click to expand';
+  const open = 'open' in named ? ' open' : '';
+  return `\n<details${open}>\n<summary>${summary}</summary>\n\n${inner.trim()}\n\n</details>\n`;
+};

--- a/scripts/shortcodes/index.ts
+++ b/scripts/shortcodes/index.ts
@@ -19,7 +19,10 @@ import { anchor } from './anchor.ts';
 import { label } from './label.ts';
 import { teamSize } from './team-size.ts';
 import { misusedTerms } from './misused-terms.ts';
-import { upstreamLink, noop } from './upstream-link.ts';
+import { upstreamLink, teamMembersLink, noop } from './upstream-link.ts';
+import { designDocumentHeader } from './design-document-header.ts';
+import { note } from './note.ts';
+import { details } from './details.ts';
 
 const HANDLERS: Record<string, ShortcodeHandler> = {
   youtube,
@@ -54,6 +57,10 @@ const HANDLERS: Record<string, ShortcodeHandler> = {
     'プロダクト優先順位',
     'https://handbook.gitlab.com/handbook/product/product-priorities/',
   ),
+  'engineering/design-document-header': designDocumentHeader,
+  'team-by-manager-slug': teamMembersLink,
+  'team-by-manager-role': teamMembersLink,
+  'team-by-departments': teamMembersLink,
   // JS-driven UI controls in upstream — drop silently in the static export.
   'all-remote/country-select': noop,
 };
@@ -66,6 +73,8 @@ const PAIRED_HANDLERS: Record<string, PairedShortcodeHandler> = {
   card,
   alert,
   panel,
+  details,
+  note,
 };
 
 // Matches both `{{< name args >}}` and `{{% name args %}}`. Names allow

--- a/scripts/shortcodes/note.ts
+++ b/scripts/shortcodes/note.ts
@@ -1,0 +1,6 @@
+import type { PairedShortcodeHandler } from './types.ts';
+
+// Docsy-GitLab `note` shortcode: wraps inner Markdown in a blue note callout.
+export const note: PairedShortcodeHandler = (_args, inner) => {
+  return `\n<div class="my-4 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r">\n\n<p class="!mt-0 !mb-1 font-bold text-blue-700">Note:</p>\n\n${inner.trim()}\n\n</div>\n`;
+};

--- a/scripts/shortcodes/upstream-link.ts
+++ b/scripts/shortcodes/upstream-link.ts
@@ -1,4 +1,6 @@
-import type { ShortcodeHandler } from './types.ts';
+import { readFile } from 'node:fs/promises';
+import { parse as parseYaml } from 'yaml';
+import type { ShortcodeHandler, ShortcodeContext } from './types.ts';
 
 // Generic placeholder for shortcodes that render large data-driven sections
 // (e.g. a list of all team members or all KPI dashboards) we don't carry
@@ -8,6 +10,116 @@ import type { ShortcodeHandler } from './types.ts';
 // multiple placeholder handlers.
 export function upstreamLink(label: string, url: string): ShortcodeHandler {
   return () => {
+    return `\n<p class="my-3 text-sm text-gray-600 italic">${label}は <a href="${url}" rel="external noopener">原文 (英語)</a> を参照してください。</p>\n`;
+  };
+}
+
+async function readUpstreamPath(ctx: ShortcodeContext): Promise<string | null> {
+  const raw = await readFile(ctx.filePath, 'utf8');
+  const m = /^---\r?\n([\s\S]*?)\r?\n---/.exec(raw);
+  if (!m) return null;
+  const fm = (parseYaml(m[1]) as Record<string, unknown>) ?? {};
+  return typeof fm['upstream_path'] === 'string' ? fm['upstream_path'] : null;
+}
+
+// Per-page anchor IDs for team/member shortcodes.
+// Key: upstream_path value (with trailing slash). Value: anchor fragment (no #).
+// Determined by inspecting each live upstream page for the heading immediately
+// above where the shortcode renders. Empty string = link to page top.
+const TEAM_ANCHORS: Record<string, string> = {
+  '/handbook/engineering/ai/agent-foundations/': 'team-members',
+  '/handbook/engineering/ai/ai-coding/': 'team-members',
+  '/handbook/engineering/ai/ai-framework/': '-team-members',
+  '/handbook/engineering/ai/context-systems/': 'team-members',
+  '/handbook/engineering/ai/custom-models/': 'team-members',
+  '/handbook/engineering/ai/editor-extensions-multi-platform/': '-team-members',
+  '/handbook/engineering/ai/editor-extensions-vscode/': 'group-members',
+  '/handbook/engineering/ai/search/': 'team-members',
+  '/handbook/engineering/ai/workflow-catalog/': 'team-members',
+  '/handbook/engineering/data-engineering/analytics/platform-insights/': 'team-members',
+  '/handbook/engineering/data-engineering/database-excellence/database-frameworks/': 'team-members',
+  '/handbook/engineering/data-engineering/database-excellence/database-operations/': 'team-members',
+  '/handbook/engineering/development/fulfillment/fulfillment-platform/': 'team-members',
+  '/handbook/engineering/development/fulfillment/provision/': 'team-members',
+  '/handbook/engineering/development/fulfillment/seat-management/': 'team-members',
+  '/handbook/engineering/development/fulfillment/utilization/': 'team-members',
+  '/handbook/engineering/development/growth/': 'all-team-members',
+  '/handbook/engineering/development/sec/secure/': 'team-members',
+  '/handbook/engineering/development/sec/secure/secret-detection/': 'our-team',
+  '/handbook/engineering/development/sec/secure/vulnerability-research/': 'vulnerability-research-team',
+  '/handbook/engineering/development/sec/security-risk-management/security-insights/': 'security-insights-team-structure',
+  '/handbook/engineering/development/sec/software-supply-chain-security/': 'pipeline-security',
+  '/handbook/engineering/development/sec/software-supply-chain-security/anti-abuse/': 'group-members',
+  '/handbook/engineering/devops/create/code-review/': 'group-members',
+  '/handbook/engineering/devops/create/code-review/backend/': 'group-members',
+  '/handbook/engineering/devops/create/code-review/frontend/': 'team-members',
+  '/handbook/engineering/devops/create/engineers/': 'createcode-review-backend',
+  '/handbook/engineering/devops/create/remote-development/': 'team-members',
+  '/handbook/engineering/devops/create/source-code/backend/': 'team-members',
+  '/handbook/engineering/devops/create/source-code/frontend/': 'team-members',
+  '/handbook/engineering/devops/package/': 'team-members',
+  '/handbook/engineering/devops/plan/knowledge/': 'team-members',
+  '/handbook/engineering/devops/plan/product-planning/': 'team-members',
+  '/handbook/engineering/devops/plan/project-management/': 'team-members',
+  '/handbook/engineering/devops/runner/': 'ci-functions-platform',
+  '/handbook/engineering/devops/runner/ci-functions-platform/': 'team-members',
+  '/handbook/engineering/devops/runner/environments/': 'team-members',
+  '/handbook/engineering/devops/runner/runner-core/': 'team-members',
+  '/handbook/engineering/devops/verify/': 'verifypipeline-authoring',
+  '/handbook/engineering/devops/verify/ci-platform/': 'team-members',
+  '/handbook/engineering/devops/verify/pipeline-authoring/': 'team-members',
+  '/handbook/engineering/devops/verify/pipeline-execution/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/data-access/': 'gitaly',
+  '/handbook/engineering/infrastructure-platforms/developer-experience/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/developer-experience/api/': 'members',
+  '/handbook/engineering/infrastructure-platforms/developer-experience/development-analytics/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/developer-experience/development-tooling/': 'team-structure',
+  '/handbook/engineering/infrastructure-platforms/developer-experience/performance-enablement/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/developer-experience/test-governance/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/gitlab-dedicated/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/gitlab-dedicated/ecosystem/': 'what-others-own',
+  '/handbook/engineering/infrastructure-platforms/gitlab-dedicated/environment-automation/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/gitlab-dedicated/switchboard/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/gitlab-dedicated/us-public-sector-services/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/gitlab-delivery/build/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/gitlab-delivery/delivery/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/gitlab-delivery/distribution/': 'distribution-build-team',
+  '/handbook/engineering/infrastructure-platforms/gitlab-delivery/operate/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/gitlab-delivery/runway/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/production-engineering/fleet-management/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/production-engineering/networking-and-incident-management/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/production-engineering/observability/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/tenant-scale/': 'geo',
+  '/handbook/engineering/infrastructure-platforms/tenant-scale/cells-infrastructure/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/tenant-scale/geo/': 'the-geo-team',
+  '/handbook/engineering/infrastructure-platforms/tenant-scale/git/': 'team',
+  '/handbook/engineering/infrastructure-platforms/tenant-scale/gitaly/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/tenant-scale/organizations/': 'team-members',
+  '/handbook/engineering/infrastructure-platforms/tenant-scale/tenant-services/': 'team-members',
+};
+
+// Placeholder for shortcodes that render team/member data from GitLab's people
+// system. Emits a notice with a link to the corresponding section on the live
+// upstream page. The anchor is looked up from TEAM_ANCHORS by upstream_path;
+// falls back to page top if the path isn't in the map.
+export const teamMembersLink: ShortcodeHandler = async (_args, ctx) => {
+  const upstreamPath = await readUpstreamPath(ctx);
+  const anchor = upstreamPath ? (TEAM_ANCHORS[upstreamPath] ?? '') : '';
+  const url = upstreamPath
+    ? `https://handbook.gitlab.com${upstreamPath}${anchor ? '#' + anchor : ''}`
+    : 'https://handbook.gitlab.com';
+  return `\n<p class="my-3 text-sm text-gray-600 italic">チームメンバー情報は <a href="${url}" rel="external noopener">原文 (英語)</a> を参照してください。</p>\n`;
+};
+
+// Placeholder for shortcodes that render team/member data from GitLab's people
+// system. Emits a notice with a link to the corresponding section on the live
+// upstream page, resolved from the file's `upstream_path` frontmatter.
+export function upstreamSection(label: string, anchor: string): ShortcodeHandler {
+  return async (_args, ctx) => {
+    const upstreamPath = await readUpstreamPath(ctx);
+    const url = upstreamPath
+      ? `https://handbook.gitlab.com${upstreamPath}#${anchor}`
+      : 'https://handbook.gitlab.com';
     return `\n<p class="my-3 text-sm text-gray-600 italic">${label}は <a href="${url}" rel="external noopener">原文 (英語)</a> を参照してください。</p>\n`;
   };
 }


### PR DESCRIPTION
## Summary

- `engineering/design-document-header`（228件）: フロントマターから Status / Authors / Coach / DRIs / Owning Stage / Created を読み取りメタデータテーブルを生成。免責アラートも付与
- `details`（12件）: ネイティブ HTML `<details>`/`<summary>` に変換。`summary` / `open` 引数対応
- `note`（2件）: 青いカラーの Note callout ボックスに変換
- `team-by-manager-slug` / `team-by-manager-role` / `team-by-departments`（計75件）: 各ページの `upstream_path` から `TEAM_ANCHORS` マップを引き、該当セクションへの原文リンクを生成。68ページ分のアンカー ID を upstream HTML から実測して登録済み

## Test plan

- [ ] `npm run transform:shortcodes -- --all` を実行して上記ショートコードが Unknown に出なくなることを確認
- [ ] 代表ページ（`engineering/ai/duo-chat/`, `engineering/devops/runner/`, `engineering/architecture/design-documents/protocells/`）でリンク先 URL が正しいことを確認
- [ ] `npm run build` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)