### PR TITLE
fix: mobile nav & layout improvements

### DIFF
--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -1,0 +1,10 @@
+---
+import BaseLayout from './BaseLayout.astro';
+import MobileNav from '~/components/MobileNav.astro';
+
+type Props = Parameters<typeof BaseLayout>[0];
+---
+<BaseLayout {...Astro.props}>
+  <MobileNav hiddenFrom="md" />
+  <slot />
+</BaseLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,31 +1,40 @@
 ---
-import BaseLayout from '~/layouts/BaseLayout.astro';
+import PageLayout from '~/layouts/PageLayout.astro';
+import Sidebar from '~/components/Sidebar.astro';
 ---
-<BaseLayout
+<PageLayout
   title="このサイトについて"
   description="GitLab Handbook 非公式日本語訳サイトについて"
+  wide
 >
-  <h1>このサイトについて</h1>
-  <p>
-    このサイトは <a href="https://handbook.gitlab.com/" rel="external noopener">GitLab Handbook</a>
-    のコミュニティによる非公式日本語訳プロジェクトです。
-  </p>
+  <div class="md:grid md:grid-cols-[18rem_minmax(0,1fr)] md:gap-8">
+    <div class="hidden md:block md:sticky md:top-4 md:self-start md:max-h-[calc(100vh-2rem)] md:overflow-y-auto md:overflow-x-hidden md:pr-2">
+      <Sidebar />
+    </div>
+    <article class="min-w-0">
+      <h1>このサイトについて</h1>
+      <p>
+        このサイトは <a href="https://handbook.gitlab.com/" rel="external noopener">GitLab Handbook</a>
+        のコミュニティによる非公式日本語訳プロジェクトです。
+      </p>
 
-  <h2>翻訳の方針</h2>
-  <ul>
-    <li>翻訳は <a href="https://claude.com/" rel="external noopener">Anthropic Claude</a> による機械翻訳を基にしています。</li>
-    <li>原文の更新を定期的に検出し、差分のみ再翻訳します。</li>
-    <li>翻訳が古い可能性があるページには警告バナーを表示します。</li>
-  </ul>
+      <h2>翻訳の方針</h2>
+      <ul>
+        <li>翻訳は AI による機械翻訳を基にしています。</li>
+        <li>原文の更新を定期的に検出し、差分のみ再翻訳します。</li>
+        <li>翻訳が古い可能性があるページには警告バナーを表示します。</li>
+      </ul>
 
-  <h2>ライセンスと免責事項</h2>
-  <ul>
-    <li>原文ライセンス: <a href="https://creativecommons.org/licenses/by-sa/4.0/" rel="external noopener">CC BY-SA 4.0</a></li>
-    <li>本翻訳も同ライセンスで配布します。</li>
-    <li>このサイトは GitLab Inc. とは関係ありません。GitLab のロゴ・マスコット・ブランドカラーは使用していません。</li>
-    <li>正確性が重要な場合は、必ず原文 (英語) を参照してください。</li>
-  </ul>
+      <h2>ライセンスと免責事項</h2>
+      <ul>
+        <li>原文ライセンス: <a href="https://creativecommons.org/licenses/by-sa/4.0/" rel="external noopener">CC BY-SA 4.0</a></li>
+        <li>本翻訳も同ライセンスで配布します。</li>
+        <li>このサイトは GitLab Inc. とは関係ありません。GitLab のロゴ・マスコット・ブランドカラーは使用していません。</li>
+        <li>正確性が重要な場合は、必ず原文 (英語) を参照してください。</li>
+      </ul>
 
-  <h2>コントリビューション</h2>
-  <p>誤訳の修正や改善提案は GitHub リポジトリの Issue / Pull Request で受け付けています。</p>
-</BaseLayout>
+      <h2>コントリビューション</h2>
+      <p>誤訳の修正や改善提案は GitHub リポジトリの Issue / Pull Request で受け付けています。</p>
+    </article>
+  </div>
+</PageLayout>

--- a/src/pages/handbook/[...slug].astro
+++ b/src/pages/handbook/[...slug].astro
@@ -1,8 +1,7 @@
 ---
-import BaseLayout from '~/layouts/BaseLayout.astro';
+import PageLayout from '~/layouts/PageLayout.astro';
 import StaleBanner from '~/components/StaleBanner.astro';
 import Sidebar from '~/components/Sidebar.astro';
-import MobileNav from '~/components/MobileNav.astro';
 import Toc from '~/components/Toc.astro';
 import Breadcrumbs from '~/components/Breadcrumbs.astro';
 import { getCollection, render, type CollectionEntry } from 'astro:content';
@@ -25,16 +24,14 @@ const { Content, headings } = await render(page);
 const upstreamBase = import.meta.env.PUBLIC_UPSTREAM_BASE ?? 'https://handbook.gitlab.com';
 const upstreamUrl = new URL(page.data.upstream_path, upstreamBase).toString();
 ---
-<BaseLayout
+<PageLayout
   title={page.data.title}
   description={page.data.description}
   upstreamPath={page.data.upstream_path}
   wide
 >
-  <MobileNav hiddenFrom="md" />
-
   <div class="md:grid md:grid-cols-[18rem_minmax(0,1fr)] md:gap-8 xl:grid-cols-[18rem_minmax(0,1fr)_20rem]">
-    <div class="hidden md:block md:sticky md:top-4 md:self-start md:max-h-[calc(100vh-2rem)] md:overflow-y-auto md:pr-2">
+    <div class="hidden md:block md:sticky md:top-4 md:self-start md:max-h-[calc(100vh-2rem)] md:overflow-y-auto md:overflow-x-hidden md:pr-2">
       <Sidebar />
     </div>
     <article class="min-w-0" data-pagefind-body>
@@ -53,7 +50,7 @@ const upstreamUrl = new URL(page.data.upstream_path, upstreamBase).toString();
         )}
       </p>
     </article>
-    <div class="hidden xl:block xl:sticky xl:top-4 xl:self-start xl:max-h-[calc(100vh-2rem)] xl:overflow-y-auto">
+    <div class="hidden xl:block xl:sticky xl:top-4 xl:self-start xl:max-h-[calc(100vh-2rem)] xl:overflow-y-auto xl:overflow-x-hidden">
       <Toc headings={headings} />
     </div>
   </div>
@@ -70,4 +67,4 @@ const upstreamUrl = new URL(page.data.upstream_path, upstreamBase).toString();
       pre.replaceWith(div);
     });
   </script>
-</BaseLayout>
+</PageLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,6 @@
 ---
-import BaseLayout from '~/layouts/BaseLayout.astro';
+import PageLayout from '~/layouts/PageLayout.astro';
 import Sidebar from '~/components/Sidebar.astro';
-import MobileNav from '~/components/MobileNav.astro';
 import { getCollection } from 'astro:content';
 
 const pages = await getCollection('handbook');
@@ -11,15 +10,13 @@ function toSlug(id: string): string {
   return id.replace(/(^|\/)index$/, '$1').replace(/\/$/, '');
 }
 ---
-<BaseLayout
+<PageLayout
   title="GitLab Handbook 非公式日本語訳"
   description="GitLab Handbook のコミュニティによる非公式日本語訳。AI による機械翻訳を基にしています。"
   wide
 >
-  <MobileNav hiddenFrom="lg" />
-
-  <div class="lg:grid lg:grid-cols-[14rem_minmax(0,1fr)] lg:gap-10">
-    <div class="hidden lg:block lg:sticky lg:top-4 lg:self-start lg:max-h-[calc(100vh-2rem)] lg:overflow-y-auto lg:pr-2">
+  <div class="md:grid md:grid-cols-[18rem_minmax(0,1fr)] md:gap-8">
+    <div class="hidden md:block md:sticky md:top-4 md:self-start md:max-h-[calc(100vh-2rem)] md:overflow-y-auto md:overflow-x-hidden md:pr-2">
       <Sidebar />
     </div>
     <article class="min-w-0">
@@ -53,4 +50,4 @@ function toSlug(id: string): string {
       )}
     </article>
   </div>
-</BaseLayout>
+</PageLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -20,13 +20,14 @@
     scroll-behavior: smooth;
   }
   body {
-    @apply bg-white text-gray-900 antialiased;
+    @apply bg-white text-gray-900 antialiased overflow-x-clip;
   }
   /* Default body text size for article content. Override per-page by adding
      a Tailwind text-* utility on the <article> element (utilities win over
      base layer). */
   article {
     @apply text-base;
+    overflow-wrap: anywhere;
   }
   a {
     @apply text-accent-600 underline decoration-accent-100 underline-offset-2 hover:decoration-accent-500;
@@ -50,7 +51,7 @@
   code { @apply font-mono text-[0.9em] bg-gray-100 px-1 py-0.5 rounded; }
   pre { @apply font-mono text-sm bg-gray-900 text-gray-100 p-4 rounded overflow-x-auto my-4; }
   pre code { @apply bg-transparent p-0; }
-  table { @apply w-full my-4 border-collapse; }
+  table { @apply block w-full my-4 border-collapse overflow-x-auto; }
   th, td { @apply border border-gray-200 px-3 py-2 text-left; }
   th { @apply bg-gray-50; }
   /* Tailwind Preflight forces `img { display: block }`. Upstream handbook


### PR DESCRIPTION
## Summary

- **PageLayout 新設**: `BaseLayout + MobileNav` をラップした `PageLayout.astro` を追加。新規ページはこれを使うだけでモバイルナビボタンが自動付与される
- **サイドバー統一**: トップページ・about ページ・handbook コンテンツページのサイドバー幅 (`18rem`) とブレークポイント (`md`) を統一。`/about/` にもサイドバーを追加
- **横スクロール防止**: `body` に `overflow-x: clip`、テーブルを `block + overflow-x: auto`、`article` に `overflow-wrap: anywhere`、サイドバーコンテナに `overflow-x: hidden`
- **about ページ更新**: 翻訳ツールの記述を「Anthropic Claude」から「AI」に汎用化

## Changes

| ファイル | 変更内容 |
|---|---|
| `src/layouts/PageLayout.astro` | 新規作成 |
| `src/pages/index.astro` | PageLayout 切替・サイドバー統一 |
| `src/pages/about.astro` | PageLayout 切替・サイドバー追加 |
| `src/pages/handbook/[...slug].astro` | PageLayout 切替・インライン MobileNav 削除 |
| `src/styles/global.css` | 横スクロール防止 CSS |

## Test plan

- [ ] スマホ幅で `/about/` の「ナビ」ボタンが表示される
- [ ] スマホ幅で横スクロールが発生しない（テーブル・長文 URL を含むページで確認）
- [ ] PC 幅でトップ・about・handbook ページのサイドバー幅が揃っている
- [ ] `npm run build` がエラーなく完了する

🤖 Generated with [Claude Code](https://claude.com/claude-code)