### PR TITLE
fix: use window.PagefindUI instead of ES module import

### DIFF
--- a/src/components/SearchModal.astro
+++ b/src/components/SearchModal.astro
@@ -72,8 +72,9 @@
           document.head.appendChild(link);
         });
         const url = '/pagefind/pagefind-ui.js';
-        const mod: any = await import(/* @vite-ignore */ url);
-        new mod.PagefindUI({
+        await import(/* @vite-ignore */ url);
+        const PagefindUI = (window as any).PagefindUI;
+        new PagefindUI({
           element: '#pagefind-container',
           showSubResults: true,
           resetStyles: false,


### PR DESCRIPTION
## 概要

本番環境で検索モーダルを開くと「検索インデックスは本番ビルド時にのみ生成されます」というエラーが表示される問題を修正します。

## 原因

`pagefind-ui.js` は ES module ではなく IIFE 形式のスクリプトで、`window.PagefindUI = mt` という形でグローバルに登録しています。

```js
// pagefind-ui.js の末尾
window.PagefindUI=mt;})();
```

`import('/pagefind/pagefind-ui.js')` はファイルの読み込み自体は成功しますが、返り値の `mod` は空のオブジェクト `{}` となるため、`mod.PagefindUI` が `undefined` になります。結果として `new mod.PagefindUI(...)` が `TypeError` を throw し、catch ブロックでエラーメッセージが表示されていました。

## 修正内容

dynamic `import()` 後に `window.PagefindUI` を参照するように変更しました。

```diff
- const mod: any = await import(/* @vite-ignore */ url);
- new mod.PagefindUI({
+ await import(/* @vite-ignore */ url);
+ const PagefindUI = (window as any).PagefindUI;
+ new PagefindUI({
```

## 確認方法

- 本番デプロイ後、`Ctrl+K` で検索モーダルを開き、検索が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)