### PR TITLE
fix: pass PUBLIC_GA4_ID to build step in deploy workflow

### DIFF
--- a/.github/workflows/app_deploy.yml
+++ b/.github/workflows/app_deploy.yml
@@ -30,6 +30,7 @@ jobs:
         env:
           SITE_URL: ${{ vars.SITE_URL }}
           PUBLIC_R2_BASE: ${{ vars.PUBLIC_R2_BASE }}
+          PUBLIC_GA4_ID: ${{ vars.PUBLIC_GA4_ID }}
 
       - uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca # v1.5.0
         with:


### PR DESCRIPTION
## Summary

- `app_deploy.yml` のビルドステップに `PUBLIC_GA4_ID` 環境変数を追加
- Astro の静的サイト（SSG）では `import.meta.env.PUBLIC_*` はビルド時に埋め込まれるため、GitHub Actions のビルドステップに渡す必要があった
- Cloudflare Pages ダッシュボードの環境変数は direct-upload 方式では参照されないため、GA4 タグがレンダリングされていなかった

## Test plan

- [ ] GitHub リポジトリの Variables に `PUBLIC_GA4_ID = G-ED5RXHWDV6` を追加する
- [ ] このPRをマージして deploy ワークフローが成功することを確認する
- [ ] 本番サイトのソースコードに gtag スクリプトが含まれていることを確認する
- [ ] GA4 管理画面でデータが受信されていることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)