### PR TITLE
translation: job-description-library (1 files)

### DIFF
--- a/content/ja/handbook/job-description-library/index.md
+++ b/content/ja/handbook/job-description-library/index.md
@@ -1,0 +1,13 @@
+---
+title: "職務説明ライブラリ"
+linkTitle: "職務説明ライブラリ"
+manualLinkRelref: "/job-description-library/"
+no_list: true
+upstream_path: "/handbook/job-description-library/"
+upstream_sha: "fe88192cad67a795a237396e552566cb08c118b9"
+translated_at: "2026-04-29T06:00:00Z"
+translator: claude
+stale: false
+---
+
+このページは[職務説明ライブラリ](/job-description-library/)へのサイドバーリンクを追加するためのプレースホルダーページです。

--- a/translation-state/manifest.json
+++ b/translation-state/manifest.json
@@ -515,6 +515,13 @@
       "model": "claude-sonnet-4-6",
       "input_hash": "37fb2123fbe1f44e2c3e1a2e0f042a673cd35dc2ac7dfc265a993ada242ba0e1"
     },
+    "content/handbook/job-description-library/_index.md": {
+      "path": "content/handbook/job-description-library/_index.md",
+      "upstream_sha": "fe88192cad67a795a237396e552566cb08c118b9",
+      "translated_at": "2026-04-29T06:00:00Z",
+      "model": "claude-sonnet-4-6",
+      "input_hash": "84869efa9609805ee2df8bb8e9f082aab3d9684851fa2d651851babe3b5f72d6"
+    },
     "content/handbook/marketing/digital-experience/_index.md": {
       "path": "content/handbook/marketing/digital-experience/_index.md",
       "upstream_sha": "2d678e92f3fbc59843a2973bbfa95041c6aef07f",


### PR DESCRIPTION
## Summary
- job-description-library セクションの日本語翻訳を追加（1 ファイル）
- `upstream` サブモジュールを eb9c7122b4 に更新
- `translation-state/manifest.json` に該当ファイル分のエントリのみを追加

## Test plan
- [ ] `npm run check` を通過
- [ ] `npm run build` を通過
- [ ] サイドバーに新セクションが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)