### PR TITLE
fix(ci): upstream 由来のリンク切れ画像で deploy を落とさない

### DIFF
--- a/scripts/upload-images-r2.ts
+++ b/scripts/upload-images-r2.ts
@@ -135,9 +135,11 @@ async function main() {
 
   console.log(`\n${uploaded} uploaded, ${skipped} already in R2, ${missing.length} missing in upstream/static.`);
   if (missing.length > 0) {
-    console.warn('Missing (referenced in Markdown but not found under upstream/static):');
+    // upstream のマークダウン中に書かれていても upstream/static に実体が無い参照
+    // （= upstream 側で元々リンク切れ。handbook.gitlab.com でも 403 で表示できない）
+    // はこちらでは直しようが無いので、警告のみ出してデプロイは通す。
+    console.warn('Missing (referenced in Markdown but not found under upstream/static — upstream-side broken refs, ignored):');
     for (const u of missing) console.warn(`  ${u}`);
-    process.exitCode = 2;
   }
 }
 


### PR DESCRIPTION
## 概要

`main` への push で動く Deploy ワークフローの `Sync referenced images to R2 (idempotent)` ステップが、upstream のマークダウンに含まれる **upstream-side リンク切れ画像 98 件** を理由に exit code 2 で失敗していました。

これらの画像は upstream のマークダウン本文に書かれているものの、upstream の static ディレクトリには実体ファイルが無く、本家 [handbook.gitlab.com](https://handbook.gitlab.com/) でも 403 で表示できない状態です。**こちら側で原状回復できない upstream 由来の broken refs** のため、警告のみ出してデプロイは通すように変更します。

## 検証

- 実在する upstream 画像 → handbook.gitlab.com で `200`
- missing list の 6 サンプル → handbook.gitlab.com で **すべて `403`**
- 例: `https://handbook.gitlab.com/handbook/marketing/brand-and-product-marketing/product-and-solution-marketing/it-groups/` の HTML には `<img src=".../images/it-groups-1.0.png">` が残っており、その URL は 403

98 画像の参照元は upstream/content の 54 ユニーク handbook ページに散らばっています（engineering: 16、marketing: 22、customer-success: 8、enterprise-data: 3、その他: 5）。

## 失敗していた run

https://github.com/kyama0/gitlab-handbook-ja/actions/runs/25427720384/job/74585505939

## Test plan

- [ ] CI が green になる
- [ ] 次の `main` deploy が `Sync referenced images to R2` を通過する
- [ ] missing 画像のリストはログに warning として残る

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * アップロード処理でアップストリーム側の不完全な参照に対する警告メッセージを改善しました。デプロイメントはこれ以降も正常に続行されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->