### PR TITLE
translation: 10 handbook jetbrains-ides + ai pages

### DIFF
--- a/content/handbook/tools-and-tips/ai/_index.md
+++ b/content/handbook/tools-and-tips/ai/_index.md
@@ -1,0 +1,13 @@
+---
+title: GitLab における AI 活用のヒント
+simple_list: true
+upstream_path: /handbook/tools-and-tips/ai/
+upstream_sha: 6f672d050777a6a6cb33fc5f31ccf71ebdd5b812
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+このハンドブックセクションには、GitLab で AI を活用するための便利なヒントが掲載されています。GitLab チームメンバーは、[こちら](https://internal.gitlab.com/handbook/ai-security-at-gitlab/ai-tool-usage-requirements/) の汎用 AI ツール利用要件に精通しておく必要があります。
+
+詳細についてはサブページに進んでください。

--- a/content/handbook/tools-and-tips/ai/claude.md
+++ b/content/handbook/tools-and-tips/ai/claude.md
@@ -1,0 +1,207 @@
+---
+title: "Claude.ai のヒント"
+upstream_path: /handbook/tools-and-tips/ai/claude/
+upstream_sha: 6f672d050777a6a6cb33fc5f31ccf71ebdd5b812
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+[Claude.ai](https://claude.ai/) を使って AI をワークフロー、ツール、プロセスに取り入れ、効率を高める方法を学びましょう。Claude を使うと、コンテンツの執筆、アウトラインやドキュメントの作成、コンテンツの要約、データベースマイグレーションや SQL ステートメントの生成、リファクタリングの推奨など、さまざまな作業ができます。
+
+## アクセス
+
+[claude.ai](https://claude.ai/) を開き、SSO ログインにチームメンバーのメールアドレスを使用します。[Okta](/handbook/security/corporate/end-user-services/okta/) の Claude タイルからもアクセスできます。[利用ガイドラインと FAQ](https://internal.gitlab.com/handbook/company/ai-at-gitlab/#usage-guidelines-and-faqs)（社内）も確認してください。
+
+## 関連リソース
+
+1. [GitLab における AI 活用 イニシアチブ](https://internal.gitlab.com/handbook/company/ai-at-gitlab/)（社内）
+   - [GitLab における AI 活用ガイドラインと FAQ](https://internal.gitlab.com/handbook/company/ai-at-gitlab/#usage-guidelines-and-faqs) を確認してください
+1. [Claude.ai サポート記事コレクション](https://support.anthropic.com/en/collections/4078531-claude-ai)
+1. [Claude のトレーニングデータはどこまで最新ですか？](https://support.anthropic.com/en/articles/8114494-how-up-to-date-is-claude-s-training-data)
+1. [`#ai-at-gitlab` Slack チャンネル](https://gitlab.enterprise.slack.com/archives/C085M5071LG) に参加する
+
+## ヒント
+
+> **注** Claude.ai に関する公開ユースケースとヒントのみをドキュメント化し、それ以外は[社内ハンドブック](https://internal.gitlab.com/handbook/company/ai-at-gitlab/) で SAFE に保管してください。
+
+Claude.ai は様々な質問やトピックに回答できます。創造的に、好奇心を持って探求し、最適なチャットプロンプトを反復してみましょう。[GitLab Duo Chat](gitlab-duo.md) も [Anthropic Claude を LLM の 1 つとして利用している](https://docs.gitlab.com/ee/user/gitlab_duo_chat/) ため、似たチャットプロンプトをテストして再利用できます。
+
+### アプリケーションと CLI
+
+1. macOS で Claude アプリケーションを使うには、[Claude for Desktop](https://claude.ai/download) をダウンロードしてください。
+1. Anthropic API アクセス
+   - Anthropic API キーが必要です。[社内ハンドブック](https://internal.gitlab.com/handbook/legal-and-corporate-affairs/legal-privacy/#requests-for-anthropic-api-key-use) のガイダンスに従ってください。
+1. Anthropic CLI（API アクセスが必要）
+   - [Anthropic SDK](https://docs.anthropic.com/en/docs/initial-setup#install-the-sdk) と CLI 用のコミュニティプロジェクト [anthropic-cli](https://github.com/dvcrn/anthropic-cli) について学びましょう
+
+### トークンの上限
+
+> [!note]
+> このセクションは [コンテキストウィンドウ](https://docs.anthropic.com/en/docs/build-with-claude/context-windows) におけるトークン上限のヒントを扱います。API のレート制限については [Anthropic のレート制限ドキュメント](https://docs.anthropic.com/en/api/rate-limits#rate-limits) を確認してください。
+
+Claude を使う際にレート制限に達するのを避けるため、以下のヒントに従うことをお勧めします:
+
+- 適切な thinking モードを設定してください。Extended の方が、アップロードと生成コンテンツのコンテキストをより多くサポートしているようです。
+- 応答モードを Concise（簡潔）に設定して、Claude の応答長を短くしてください。
+- 再プロンプトする前に、前のプロンプトを編集して新しい依頼を含めるようにしてみてください。
+- プロンプトでは具体的に依頼してください。3.7 は依頼以上のことを構築しようとする傾向があるので、依頼した変更のみを行うよう、より反復的なアプローチで明示してください。
+
+> [!note]
+> 本記事執筆時点では _Claude 3.5 Sonnet_ の方がレート制限が高いため、これで用が足りていて長い会話を必要とする場合は、_Claude 3.7 Sonnet_ のレート制限が引き上げられるまでの間、有力な選択肢になりえます。ただし、3.7 版モデルの改善点は享受できなくなります。
+
+## プロンプトライブラリの例
+
+以下は部門ごとに整理した便利なプロンプトのコレクションで、それぞれのプロンプトに利用例を添えて、チームメンバーが AI アシスタントを効果的に活用できるようにしています。
+
+### Sales 部門
+
+#### 価値提案分析プロンプト
+
+```markdown
+Analyze how a company's features address key challenges in the [MARKET SEGMENT] space. Focus on:
+1. Pain points solved
+2. Feature advantages
+3. Customer support benefits
+4. Integration capabilities
+5. ROI potential
+```
+
+**利用例:** 金融サービス業界の見込み客との営業電話の準備時。
+
+#### セールスメールテンプレート生成
+
+```markdown
+Generate a personalized sales email to [PROSPECT TYPE] who is currently using [CURRENT SOLUTION].
+Include:
+- Pain points they might be experiencing
+- Specific features that address these pain points
+- A clear value proposition
+- Soft call-to-action for a demo
+Keep the tone professional but conversational and limit to 200 words.
+```
+
+**利用例:** 分断されたツールを使用しているヘルスケア企業の開発チームリードに対して、シングルアプリケーションのアプローチによるメリットを訴求する、テーラーメイドのアウトリーチメールを作成するとき。
+
+### Marketing 部門
+
+#### コンテンツブリーフ作成
+
+```markdown
+Create a detailed content brief for a [CONTENT TYPE] about [TOPIC] targeted at [AUDIENCE].
+Include:
+- Proposed title options (3-5)
+- Key messages to convey
+- SEO keywords to target
+- Outline with section headings
+- Suggested data points or case studies to include
+- Call-to-action recommendations
+```
+
+**利用例:** 包括的なブログ投稿を計画するとき。
+
+#### ソーシャルメディアキャンペーンプランナー
+
+```markdown
+Develop a 2-week social media campaign promoting [FEATURE/PRODUCT] across LinkedIn and Twitter.
+For each platform, create:
+- 5 unique post ideas with copy variants (280 chars for Twitter, 700 chars for LinkedIn)
+- Hashtag recommendations
+- Suggested posting schedule
+- Ideas for engagement questions
+Focus on highlighting [SPECIFIC BENEFIT] and target [TARGET AUDIENCE].
+```
+
+**利用例:** AI 支援機能を宣伝するキャンペーンを作成するとき。
+
+### General & Administrative
+
+#### ポリシードキュメント要約
+
+```markdown
+Summarize the following [POLICY/DOCUMENT] into:
+1. A one-paragraph executive summary
+2. 5-7 bullet points of key takeaways
+3. A list of any action items or compliance requirements
+4. A simple table showing changes from previous version (if applicable)
+```
+
+**利用例:** 四半期のコンプライアンストレーニング前にチームに配布するため、長文の更新済みセキュリティコンプライアンスドキュメントを、簡潔に把握できる形に蒸留するとき。
+
+#### データ分析アシスタント
+
+```markdown
+Help analyze this [DATA SET] to identify:
+1. Key trends and patterns
+2. Anomalies or outliers
+3. Correlations between variables
+4. Business implications
+5. Suggested next steps or areas for deeper investigation
+
+Provide both summary insights and specific data points that support your analysis.
+```
+
+**利用例:** ビジネスユーザーが四半期の経費レポートを分析し、部門間の支出パターンを特定し、異常な取引にフラグを立て、リーダーシップ向けにコスト削減の推奨事項を生成するとき。
+
+### Product 部門
+
+#### ユーザーストーリー生成
+
+```markdown
+Create detailed user stories for implementing a [FEATURE]. For each user story:
+- Follow the format: "As a [USER TYPE], I want to [ACTION] so that [BENEFIT]"
+- Include acceptance criteria
+- Suggest story points (1, 2, 3, 5, 8)
+- Identify potential dependencies
+- Tag with appropriate labels (frontend, backend, UX, etc.)
+```
+
+**利用例:** 包括的なユーザーストーリーを作成するとき。
+
+#### コード可視化アシスタント
+
+```markdown
+Visualize the following code to help understand:
+1. Execution flow
+2. Function calls and relationships
+3. Key dependencies
+4. Potential bottlenecks
+
+Present the visualization in [FORMAT] (Mermaid, ASCII art, etc.)
+
+Code:
+[PASTE CODE HERE]
+```
+
+**利用例:** プロダクトマネージャーと開発者が複雑な機能の実装をより深く理解するため、リファクタリング作業を計画する前に、コード実行パスや依存関係を可視化して連携するとき。
+
+### AI ワークフロープロンプト
+
+#### データセット分析
+
+```markdown
+Analyze the attached data file and provide:
+1. Summary of key content
+2. Important patterns or trends
+3. Insights grouped by priority
+4. Recommendations based on findings
+
+For [TYPE] data, focus on [SPECIFIC METRICS].
+```
+
+**利用例:** 顧客の利用データを分析して機能の採用パターンを特定し、特定のツールに最も活発に関わっているユーザーセグメントを浮き彫りにするとき。
+
+#### コードモダナイゼーションアシスタント
+
+```markdown
+Review this legacy code and provide:
+1. Explanation of current functionality
+2. Modern implementation approach
+3. Key improvements in the new version
+4. Implementation considerations and challenges
+
+Original code:
+[PASTE CODE HERE]
+```
+
+**利用例:** レガシーな自動化スクリプトを現在のベストプラクティスに合わせてモダナイズし、チームが依存している必要不可欠な機能を維持しつつ保守性を改善するとき。

--- a/content/handbook/tools-and-tips/ai/gitlab-duo.md
+++ b/content/handbook/tools-and-tips/ai/gitlab-duo.md
@@ -1,0 +1,175 @@
+---
+title: "GitLab Duo のヒント"
+upstream_path: /handbook/tools-and-tips/ai/gitlab-duo/
+upstream_sha: 6f672d050777a6a6cb33fc5f31ccf71ebdd5b812
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+AI 駆動の GitLab Duo Chat、Code Suggestions などを使って DevSecOps ワークフローを高速化する方法を学びましょう。
+
+## アクセス
+
+gitlab-com [グループ](https://gitlab.com/gitlab-com) で GitLab Duo へのアクセスが必要な場合は、[HelpLab チケット](/handbook/business-technology/enterprise-applications/guides/helplab-guide/#create-a-ticket--request) を作成して IT と連携し、グループに対して GitLab Duo を有効化してもらってください。
+
+GitLab のコントリビューターおよび co-creator も AI 駆動の GitLab Duo を活用できます。[contributors.gitlab.com/](https://contributors.gitlab.com/) のオンボーディングプロセスから始めてください。
+
+GitLab.com の顧客デモグループでチームメンバーがアクセスを必要とする場合は、`GitlabCom_Licensed_Demo_Group_Request` テンプレートを使って [Access Request](/handbook/security/corporate/end-user-services/access-requests/access-requests/) を作成してください。
+
+オンボーディングについては、[Getting Started](https://docs.gitlab.com/ee/user/get_started/getting_started_gitlab_duo.html) ドキュメントを参照してください。
+
+## IDE での GitLab Duo
+
+GitLab Duo の拡張機能を介した IDE 統合については、[エディター拡張ドキュメント](https://docs.gitlab.com/ee/editor_extensions/#available-extensions) を参照してください。
+
+## 関連リソース
+
+- [GitLab Duo ドキュメント](https://docs.gitlab.com/ee/user/gitlab_duo/)
+  - [Getting Started](https://docs.gitlab.com/ee/user/get_started/getting_started_gitlab_duo.html)
+  - [ユースケース](https://docs.gitlab.com/ee/user/gitlab_duo/use_cases.html)
+  - [Duo Code Suggestions](https://docs.gitlab.com/ee/user/project/repository/code_suggestions/)
+  - [Duo Chat](https://docs.gitlab.com/ee/user/gitlab_duo_chat/)
+- [GitLab University](https://university.gitlab.com)
+  - [AI および GitLab Duo コース](https://university.gitlab.com/learn/dashboard?labels=%5B%22Topic%22%5D&values=%5B%22AI%22%5D)
+  - [GitLab Duo Enterprise ラーニングパス](https://university.gitlab.com/learn/learning-path/gitlab-duo-enterprise-learning-path)
+- [Developer Advocacy リソース](/handbook/marketing/developer-relations/developer-advocacy/)
+  - [コンテンツライブラリ](/handbook/marketing/developer-relations/developer-advocacy/content/)（GitLab Duo のデモ、ユースケース、製品ツアー、トーク、ワークショップ、レコーディングなど）
+- [Highspot: フィールドガイド](https://gitlab.highspot.com/items/6459a4f9a583c8ebe9aa5a64)（社内のみ、フィールドチーム向け）
+- ドッグフーディング: [GitLab Duo の開発に関するブログチュートリアルシリーズ](https://about.gitlab.com/blog/2024/06/03/developing-gitlab-duo-series/)
+
+## ヒント
+
+GitLab Duo Chat は GitLab、プログラミング言語、テクノロジーなどに関する多くの質問に答えてくれます。複数のブラウザ検索タブを開く代わりに、これを活用し、質問の仕方やフォローアップの会話を作る練習をしてみましょう。チャットプロンプトと応答を試行錯誤しイテレーションしてみてください。詳しくはブログ記事 [10 best practices for AI-powered GitLab Duo Chat](https://about.gitlab.com/blog/2024/04/02/10-best-practices-for-using-ai-powered-gitlab-duo-chat/) で学べます。
+
+GitLab Duo を使ってコードを書く場合は、ブログ記事 [Top tips for efficient AI-powered Code Suggestions with GitLab Duo](https://about.gitlab.com/blog/2024/06/11/top-tips-for-efficient-ai-powered-code-suggestions-with-gitlab-duo/) も参照してください。
+
+GitLab チームメンバーや co-creator 向けに、本ハンドブックページのユースケースを探求してみてください。さらなるユースケースとワークフローは [GitLab Duo ドキュメント](https://docs.gitlab.com/ee/user/gitlab_duo/) に記載されています。
+
+オープンな機能リクエスト:
+
+1. [GitLab Duo Chat でハンドブックの質問に回答できるようにする](https://gitlab.com/gitlab-com/content-sites/handbook/-/issues/212)
+
+## ハンドブックのユースケース
+
+### ハンドブック編集の準備手順
+
+GitLab Duo Chat が [お使いの IDE または GitLab UI で動作する](https://docs.gitlab.com/ee/user/get_started/getting_started_gitlab_duo.html#step-4-prepare-to-use-gitlab-duo-in-your-ide) ことを確認してください。
+
+1. [GitLab UI](https://docs.gitlab.com/ee/user/gitlab_duo_chat/#use-gitlab-duo-chat-in-the-gitlab-ui)
+1. [Web IDE](https://docs.gitlab.com/ee/user/gitlab_duo_chat/#use-gitlab-duo-chat-in-the-web-ide)
+1. [VS Code](https://docs.gitlab.com/ee/user/gitlab_duo_chat/#use-gitlab-duo-chat-in-vs-code)
+1. [JetBrains IDE](https://docs.gitlab.com/ee/user/gitlab_duo_chat/#use-gitlab-duo-chat-in-jetbrains-ides)（IntelliJ IDEA、PyCharm など）
+
+VS Code/Web IDE で Duo Chat にアクセスするキーボードショートカット:
+
+1. `cmd shift p`（macOS）でコマンドパレットを開きます。
+1. `GitLab Duo Chat` を検索して Enter を押します。
+1. 任意: Duo Chat を右側パネルにドラッグして移動できます（[このビデオ](https://www.youtube.com/watch?v=foZpUvWPRJQ) で説明されています）。
+
+Code Suggestions を使って Markdown コンテンツを書いて補完したい場合は、[IDE 拡張設定の追加言語として](https://docs.gitlab.com/ee/user/project/repository/code_suggestions/supported_extensions.html#add-support-for-more-languages) `markdown` を設定する必要があります。ヒント: 複数のタブを開きファイルコンテンツを増やすことで、提案の[コンテキスト](https://docs.gitlab.com/ee/user/project/repository/code_suggestions/#advanced-context) と品質を高められます。ハンドブックのバックエンドメンテナーである @dnsmichi とコーヒーチャットを設定して、ライブ画面共有での学習セッションをリクエストしましょう。
+
+### Markdown のテーブルを作成する
+
+解決したい問題: `web IDE 経由でハンドブックページにテーブルを追加する方法はありますか？`
+
+以下のプロンプトを使って、事前定義のデータカラムでテーブルを作成します:
+
+```markdown
+Create a Markdown table with the following data set
+Header: Cloud, GPU type, Costs, Spec, Notes
+Fill the entries with sample data for 3 rows.
+```
+
+GitLab Duo Chat は Markdown テーブルを可視化することがあります。これを活用して結果が期待どおりであることを確認し、出力フォーマットを raw Markdown に指定するフォローアッププロンプトに進みます。
+
+```markdown
+Show the raw Markdown in a code block
+```
+
+> 注: 同じワークフローは GitLab Duo Chat の [Duo 拡張機能を備えたローカル IDE](https://docs.gitlab.com/ee/user/get_started/getting_started_gitlab_duo.html#step-4-prepare-to-use-gitlab-duo-in-your-ide) でも利用できます。
+
+### Markdown テーブルの更新やリファクタリング
+
+ときには、Markdown テーブルを複数のテーブルに分割したり、1 つに統合したり、追加の列を加える必要があります。
+
+1. IDE を開き、更新／リファクタリング対象のテーブルを選択します。
+1. GitLab Duo Chat に次のプロンプトを尋ねます:
+
+   ```markdown
+   /refactor the table for better readability. Split it by the first column into separate tables.
+   ```
+
+1. Duo Chat が応答内でテーブルを可視化したら、これを使ってテーブルが正しく分割されていることを確認します。raw 出力を求めるフォローアッププロンプトを送ることもできます:
+
+   ```markdown
+   Only show the refactored table as raw Markdown code blocks
+   ```
+
+## 開発のユースケース
+
+ブログ記事 [Developing GitLab Duo: How we are dogfooding our AI features](https://about.gitlab.com/blog/2024/05/20/developing-gitlab-duo-how-we-are-dogfooding-our-ai-features/) を読み、以下の方法を学んでください:
+
+1. コードレビューのプロセスを効率化する
+1. コメントスレッドを凝縮する
+1. 新しいドキュメントを作成する
+1. リリースノートを作成する
+1. ドキュメントサイトのナビゲーションを最適化する
+1. その他
+
+### 失敗した CI/CD パイプラインのトラブルシューティング
+
+1. 失敗したパイプラインのジョブビューに移動し、ログを確認します。[ドキュメントのステップ](https://docs.gitlab.com/ee/user/gitlab_duo_chat/examples.html#troubleshoot-failed-cicd-jobs-with-root-cause-analysis) に従って Root Cause Analysis を開始します。
+1. チャットプロンプトでフォローアップの質問を行います。たとえば、長期的にこのエラーを防ぐ方法を尋ねます。
+
+これらのユースケースは以下で探求できます:
+
+1. [Developer Advocacy チーム](/handbook/marketing/developer-relations/developer-advocacy/projects/#organisation-structure) が保守する [Duo Enterprise 製品ツアー](/handbook/marketing/developer-relations/developer-advocacy/content/#product-tours) と [Root Cause Analysis チャレンジ](https://gitlab.com/gitlab-da/use-cases/ai/ai-workflows/gitlab-duo-challenges/root-cause-analysis)
+1. [GitLab University: GitLab Duo Enterprise コース](https://university.gitlab.com/courses/gitlab-duo-enterprise)
+
+### オンボーディングと貢献
+
+チームメンバーやコミュニティコントリビューターは、AI 駆動のワークフローを活用して、迅速なオンボーディング、コードベースや GitLab に関する学習、より速いレビューサイクルでの貢献ができます。
+
+1. ソースコードベースを学び、特定の機能提案やバグ修正の実装方法を探求する。
+1. マージリクエストの要約とコードレビューをスピードアップする。
+1. 失敗する CI/CD パイプラインのトラブルシューティング。
+
+詳しくは [GitLab Duo ユースケースのドキュメント](https://docs.gitlab.com/ee/user/gitlab_duo/use_cases.html#use-gitlab-duo-to-contribute-to-gitlab) を参照してください。
+
+## GitLab Duo Quick Chat とターミナルの統合
+
+### 解決したい問題
+
+コマンドラインの引数を覚えるのは難しく、man ページを検索するのは時間がかかります。
+
+### 解決策
+
+GitLab Duo Quick Chat をターミナルと統合して、コマンドラインの操作を支援します。
+
+### セットアップ方法
+
+1. シェルプロファイル（`.bashrc`、`.zshrc` など）に以下を追加して、ターミナルがデフォルトエディターとして VSCode を使うように設定します:
+
+   ```bash
+   export EDITOR="code --wait"
+   ```
+
+2. コマンドのヘルプが必要なときは:
+   - ターミナルでコマンドを入力し始めます（例: `git rebase -i`）
+   - <kbd>Ctrl</kbd>+<kbd>x</kbd> <kbd>Ctrl</kbd>+<kbd>e</kbd> を押して、現在のコマンドラインを VSCode で開きます
+
+3. VSCode で:
+   - 入力していたコマンドが新しい一時ファイルに表示されます
+   - GitLab Duo Chat を開きます（macOS では <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>、Windows/Linux では <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> を使い、"GitLab Duo Chat" と入力します）
+   - コマンドのテキストを選択（または削除）し、目的を達成するための支援を Duo に求めます。例: 「Help me write a git command to squash my last 3 commits into one」や、「I need a command to rebase my current branch onto main and resolve conflicts interactively」
+
+4. Duo の応答を活用:
+   - Duo が改善されたコマンドを生成したら、応答内の **Insert Snippet** ボタンをクリックします
+   - ファイルを保存して（<kbd>Cmd</kbd>+<kbd>S</kbd> または <kbd>Ctrl</kbd>+<kbd>S</kbd>）、タブを閉じます
+   - 編集されたコマンドがターミナルに表示され、実行可能な状態になります
+
+### 補足
+
+- このワークフローは VSCode の統合ターミナルでも動作します
+- キーボードショートカット <kbd>C-x</kbd> <kbd>C-e</kbd> は bash/zsh の標準機能で、現在のコマンドラインを編集するためのもので、Duo 固有のものではありません

--- a/content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/code-inspection/_index.md
+++ b/content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/code-inspection/_index.md
@@ -1,0 +1,103 @@
+---
+title: "コードインスペクション"
+simple_list: true
+upstream_path: /handbook/tools-and-tips/editors-and-ides/jetbrains-ides/code-inspection/
+upstream_sha: 6f672d050777a6a6cb33fc5f31ccf71ebdd5b812
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## コードインスペクション
+
+(***「コード中の `noinspection` コメントは何ですか？」と質問するためにこのページに来た方は、詳しい説明のために [「なぜ `noinspection` コメントが存在するのか」](why-are-there-noinspection-comments/) のページを読んでください。**
+JetBrains でコードインスペクションを効果的に使う方法を学びたいだけなら、このページが探しているページです…*)
+
+JetBrains の IDE の優れた機能の 1 つに「Inspect Code」（`Code -> Inspect Code`）があります。
+
+この機能の説明はこちらをご覧ください: <https://www.jetbrains.com/help/ruby/running-inspections.html>
+
+以下のセクションでは、この機能を最大限に活用する方法について詳しく説明します。
+
+## 「Inspect Code」をクリーンに保ち「グリーンチェック」を維持する
+
+これにより、RuboCop/ESLint といったプロジェクト設定済みのリンターはもちろん、型安全性や潜在的なバグなどのカスタム IDE インスペクションも含め、すべてのコードインスペクションを実行できます。実行後、それらの結果は「Problems」ペインに表示されます。
+
+「Problems」ペインに加えて、エディター上では問題箇所が下線で示され、瞬時にフィードバックが得られます。また、各ファイルの右上にはアイコンですべての問題のサマリーが表示されます。これらすべてはマウスでホバーするとエラーへの対処方法のオプションが表示され、場合によっては自動的に修正することも可能です。
+
+そして、ファイルに問題がない場合は、ファイル右上に「グリーンチェック」が表示され、常時かつ即時のフィードバックとなります。
+
+これらは強力な時間短縮ツールとなり、「LEFTHOOK」のような pre-push フックや、それより悪い場合は CI が問題を検出するのを待つことなく、即座に問題を発見するのに役立ちます。
+
+## 「Next Error」ショートカット
+
+**プロのヒント:** `Settings -> Editor -> Code Editing -> Error Highlighting -> The 'Next Error' action goes through` を `"All Problems"` に設定すると、`F2` でファイル内のすべてのエラーを巡回でき、`Alt-Enter` と矢印キーでエラー解決オプションを表示できます。
+
+## `noinspection` コメントによる偽陽性の抑制
+
+ただし、「Inspect Code」が「偽陽性」の問題を報告することがあります。これらは通常、IDE のバグや制限、あるいはライブラリの誤った型注釈などが原因です。
+
+原因が何であれ、これらの偽陽性を抑制するのは良いことです。理由は以下のとおりです:
+
+1. これらが「Problems」ペインにノイズを発生させ、無視せざるを得なくなります。あるいは、本来は他に問題のないファイルで「Problems」ペインがポップアップしないはずなのに、ポップアップしてしまうケースもあります。
+1. 他に本物の問題がないファイルにきれいな「グリーンチェック」が表示されるのを妨げます。
+1. そのコードに不慣れな JetBrains ユーザーにとっては、それが本物の問題なのか、修正すべきものなのかを判断する手がかりがなくなります。
+
+これらの偽陽性を抑制する方法は `noinspection ...` コメントを使うことです: <https://www.jetbrains.com/help/ruby/disabling-and-enabling-inspections.html>
+
+`F2`（Next Error）の後に右矢印を押すと、問題を無視するための正しい `noinspection ...` コメントを自動で追加できます。ただし、`gitlab` プロジェクトでの RuboCop 警告を避けるため、`#` の後にスペースを手動で追加する必要があります。
+
+`noinspection` コメントを自動的に追加するには、次の手順を使います:
+
+1. コード上の警告行で `Option-Enter` を押すか（`F2` でその行を見つけた後）、または「Inspect Code」の `Problems` ペインのレポートでエラーを右クリックします。
+1. 表示されたメニューで `Suppress for statement` オプションを見つけてクリックします。
+1. 現在、Ruby では `#` の後にスペースを入れないバグがあるため、rubocop エラーを避けるため手動でスペースを追加する必要があります（TODO: これに関する Issue を RubyMine に対して登録してください）
+1. これによって、偽陽性のないクリーンなレポートとグリーンチェックが得られます :)
+
+## `noinspection` ごとに説明やリンクを添える
+
+これらの `noinspection` コメントは、JetBrains を使っていないユーザーを混乱させる可能性があります。
+
+そのため、それぞれのコメントには、なぜそれが必要だったかを説明するコメントを添え、参照可能な情報へのリンクも記載するべきです。
+
+*JetBrains のバグや制限のために必要だった場合は、[Tracked JetBrains Issues](../tracked-jetbrains-issues) ページの該当エントリを参照してください*。該当エントリがまだ存在しない場合は、次のいずれかを行ってください:
+
+1. JetBrains に対して Issue を登録し、そのページに追加する（こちらが推奨）。
+1. JetBrains の Issue を特定したり起票したりする時間がない場合は、そのページを指す `TODO:` リンクを残し、後で JetBrains の Issue を特定または起票する必要があることを示してください。
+
+## `noinspection` と説明は 1 行で書く
+
+すべての `# noinspection - <リンクや説明>` コメントは、1 行に収めるべきです。
+
+これは、古くなった／修正された `# noinspection` 行を削除する際に、関連付けられている別の説明行の削除を忘れる可能性を避けたいためです。
+
+これは、関連する `# rubocop:disable Layout/LineLength` を別の行に置く必要がある場合でも、一貫して行ってください（必要なくなった `# rubocop:disable` が残っていると、別の RuboCop 警告が発生するためです）。
+
+その他に検討した選択肢:
+
+- URL 短縮サービスを利用する案もありますが、不明な遷移先のリンクをクリックするセキュリティ面の懸念がありました。
+  [社内 URL 短縮サービスの可能性については過去に議論し却下されています](https://gitlab.com/gitlab-com/gl-infra/reliability/-/issues/861)。
+- 一部のコメントから説明やリンクを省略する選択肢もありますが、それでは「コメントの目的が分からない人」「繰り返し質問に対応せざるを得ない人」が出てしまうという、もとからある問題が解消されず、このセクションを通じて自力で答えを発見してもらうこともできなくなります。
+
+## カスタムスコープを使った `Inspect Code` の利用
+
+コードインスペクション（およびその他の JetBrains の操作）をより高速かつ強力にする方法の 1 つとして、*カスタムスコープ* の利用があります。
+
+現在作業中の機能に関連するファイルだけを選択するカスタム「Scope」を整備すれば、このレポートを使ってそれらのファイル内のすべての警告／エラーを見つけることもできます。
+
+セットアップ手順の簡単なリストはこちらです（TODO: より詳細／リンクを追加してください）:
+
+1. すべての linting プラグインが有効化・設定されていることを確認します: rubocop、eslint、prettier（Preferences の検索でこれらを探してください。デフォルトで有効なものもあります）
+1. Preferences -> Editor -> Code Editing -> Error Highlighting セクションで、`The 'Next Error' action goes through` を `All problems` に変更します
+1. デフォルトで現在のファイル内のすべてのハイライトが見られるようになります。
+1. `F2`（next error）で現在のファイル内のすべてのエラーを巡回できます。エラー上で `Option+Return` を押すと、可能な修正のメニューが開きます。
+1. 複数ファイルをチェックするには、`Inspect Code` 機能（Cmd-shift-A -> "Inspect Code"）を使い、対象として個別ファイルやカスタムスコープを選択できます。
+1. 作業中の機能やコード領域のためのファイルのみを含むカスタムスコープを設定することもできます
+    1. Preferences -> Appearance and Behavior -> Scopes
+    1. `+` でスコープを追加し、名前を付けます（例: `remote_dev`）
+    1. Include/Exclude/Recursively ボタンを使って、スコープに含めるファイルを定義します。
+    1. 他のチームメンバーと共有可能な `remote_dev` スコープ定義の現状の例: `file[gitlab]:ee/lib/remote_development//*||file[gitlab]:ee/spec/factories/remote_development//*||file[gitlab]:ee/spec/lib/remote_development//*||file[gitlab]:ee/app/services/remote_development//*||file[gitlab]:app/models/remote_development//*||file[gitlab]:ee/app/graphql/mutations/remote_development//*||file[gitlab]:ee/app/graphql/resolvers/remote_development//*||file[gitlab]:ee/app/graphql/types/remote_development//*||file[gitlab]:ee/app/models/remote_development//*||file[gitlab]:ee/spec/graphql/types/remote_development//*||file[gitlab]:ee/spec/models/remote_development//*||file[gitlab]:ee/spec/services/remote_development//*||file[gitlab]:ee/app/finders/remote_development//*||file[gitlab]:ee/spec/features/remote_development//*||file[gitlab]:ee/spec/support/shared_contexts/remote_development//*||file[gitlab]:ee/app/graphql/ee/types/user_interface.rb||file[gitlab]:ee/app/graphql/resolvers/concerns/remote_development//*||file[gitlab]:ee/app/graphql/resolvers/projects/workspaces_resolver.rb||file[gitlab]:ee/app/graphql/resolvers/users/workspaces_resolver.rb||file[gitlab]:ee/spec/requests/api/graphql/mutations/remote_development//*||file[gitlab]:ee/spec/requests/api/graphql/remote_development//*||file[gitlab]:ee/spec/finders/remote_development//*||file[gitlab]:ee/app/assets/javascripts/remote_development//*||file[gitlab]:ee/spec/frontend/remote_development//*||file[gitlab]:ee/spec/graphql/api/workspace_spec.rb`
+    1. XML ファイルを直接共有することもできます。`.idea/scopes/SCOPE_NAME.xml` 配下にあります。
+    1. Workspaces に関連した Chad の現在のスコープ例 2 つ:
+       1. すべての remote dev ファイル: <https://gitlab.com/jetbrains-ide-config/jetbrains-ide-config-gitlab/-/blob/master/dotidea/scopes/remote_dev.xml>
+       1. remote dev の services と lib ファイルのみ: <https://gitlab.com/jetbrains-ide-config/jetbrains-ide-config-gitlab/-/blob/master/dotidea/scopes/remote_dev_services___lib.xml>

--- a/content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/code-inspection/why-are-there-noinspection-comments.md
+++ b/content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/code-inspection/why-are-there-noinspection-comments.md
@@ -1,0 +1,65 @@
+---
+title: "なぜ noinspection コメントが存在するのか"
+no_list: true
+upstream_path: /handbook/tools-and-tips/editors-and-ides/jetbrains-ides/code-inspection/why-are-there-noinspection-comments/
+upstream_sha: 6f672d050777a6a6cb33fc5f31ccf71ebdd5b812
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## コード中の `noinspection` コメントは何ですか？
+
+(***この質問への回答としてこのページを案内された方は、詳しい説明のためにこのページを読んでください。**
+JetBrains でコードインスペクションを効果的に使う方法を学びたいだけなら、[コードインスペクションのメインページ](..) を参照してください*)
+
+### JetBrains は広く使われている
+
+JetBrains は強力な IDE であり、従来型の「IDE」（汎用エディターと対比される意味で）の業界リーダーとして圧倒的な位置を占めています。各種調査では、JetBrains 製の IDE を使う開発者が大きな割合を占めることが示されています（具体的な数字を得るのは難しいです。多くの調査では RubyMine や Webstorm などのエコシステム／プラットフォーム／言語ごとの個別 IDE に分かれて集計されているためです。これらを VSCode や Vim のようなマルチエコシステム対応のエディターと比較してみてください）。
+
+JetBrains 製エディターの利用状況を示す各種調査の例:
+
+- [StackOverflow 2023 開発者調査](https://survey.stackoverflow.co/2023/#section-most-popular-technologies-integrated-development-environment)
+- [Ruby on Rails 2022 コミュニティ調査](https://railsdeveloper.com/survey/2022/#what-is-your-preferred-editor)
+- [JetBrains 2022 開発者エコシステム調査](https://www.jetbrains.com/lp/devecosystem-2022/ruby/#what-editor-ide-do-you-mostly-use-for-ruby-development-)
+- [GitLab 2023 IDE/エディター利用状況（社内ドキュメントリンク）](https://docs.google.com/document/d/1tITdhdkJm5xaPiPpXQ9wW1X6M3SAMhncJYaNmQfja70/edit)
+
+### JetBrains は git フックや CI が提供するものを超えた強力なコードインスペクションをサポートする
+
+JetBrains の IDE には、IDE に組み込まれた強力な[コードインスペクション機能](..) があり、型安全性や、RuboCop や ESLint のような標準の静的解析ツールでは提供されないその他のチェックも含まれます。
+
+このサポートは、JetBrains IDE のユーザーにとって生産性を大きく押し上げます。LEFTHOOK の pre-push フックや CI パイプラインの実行と失敗を待つ必要がなく（これは長くて退屈なフィードバックループです）、リンティング／型などのエラーを瞬時にフィードバックとして受け取ることができるからです。
+
+### この機能を活用する GitLab チームメンバーや貢献者の効率を向上させる
+
+JetBrains IDE のユーザーは GitLab チームメンバーの中にも複数おり、活発な[社内 `#jetbrains-ide-users` Slack チャンネル](https://gitlab.slack.com/archives/CR08PTQ6T)が存在します。
+
+そのため、Workspaces チームのように JetBrains ユーザーが複数いるチームの一部では、機能の[`コードインスペクション`](..) をクリーンに保ち、警告／エラーが出ないようにする継続的な努力をしています。これにより、各ファイル右上の「グリーンチェック」が役立つ指標となり、それが表示されないときは何らかの問題を持ち込んだことに即座に気づけます。
+
+このアプローチは「誰もが貢献できる」という私たちのミッションも支えています。なぜなら、JetBrains を使う社外貢献者が `noinspection` コメントが整備された領域のコードに貢献したい場合、IDE 上の偽陽性警告に煩わされずに作業でき、自分が見ている警告は今のコーディングセッションや MR で自分自身が持ち込んだ問題に起因する可能性が高い、と信頼できるからです。
+
+### この機能を最大限に活用するためには偽陽性を抑制する必要がある
+
+ただし、ときには偽陽性が出るため、`noinspection` コメントで無効化して綺麗な状態を保つ必要があります。これは RuboCop、ESLint、その他類似の静的解析ツールにおける `disable` コメントに似ています。
+
+これらの偽陽性は、IDE のバグや機能不足を示していることが多いです。そのため、こうしたケースでは積極的に JetBrains に報告し、対応する Issue を JetBrains の Issue トラッカーで追跡しています。
+
+このトラッキングは [Tracked JetBrains Issues](/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/tracked-jetbrains-issues/) にあり、関連するコメントには対応する Issue エントリが参照として含まれているはずです。基となる Issue が解決され、新しい IDE リリースに含まれた時点で、[対応する `noinspection` コメントは削除できます](../tracked-jetbrains-issues/_index.md#handling-of-issues-related-to-noinspection-comments)。
+
+しかし、`noinspection` コメントの中には、デフォルトの JetBrains インスペクションルールが原因のものもあります。私たちが意図的にデフォルトルールに対する例外を作っており、そのルールを強制したくない場合です。例として、クラス／変数／モジュール／メソッド／定数の名前が長すぎる、または短すぎるという警告があります。1 つの選択肢としては、インスペクションの設定そのものを変更し、たとえばより長い名前を許可することもできます。しかし、その方法では全員が同じ JetBrains 設定をオーバーライドしておく必要があり、特に社外貢献者に対してそれを要求したり前提にしたりはしたくありません。
+
+### 全員が使う必要はないが、他のメンバーが使うことを妨げないでほしい
+
+私たちは、JetBrains を使っていないユーザーにこれらのコメントを保守してもらう必要はありません。チーム内の JetBrains ユーザーが、コメントの保守、説明コメント／TODO の追加、関連する JetBrains Issue の追跡、および修正済みあるいは古くなったものの削除に責任を持ちます。
+
+私たちがお願いしているのは、コメントを追跡している [JetBrains Issue](../tracked-jetbrains-issues/_index.md) がすでに解決されている場合を除き、[JetBrains 非利用者からこれらのコメントを削除するリクエスト](https://gitlab.com/gitlab-org/gitlab/-/issues/409823) を行わないことです。
+
+JetBrains IDE を使っていない人にとっては有用ではないかもしれませんが、JetBrains ユーザーには、このような警告がない状態を保つことで質の高いコードを書く助けになり、私たちの価値観である Efficiency（効率）、Results（結果）、Diversity/Inclusion/Belonging（多様性／包摂／所属感）を支えることになります。
+
+GitLab で広く使われている、JetBrains 以外の IDE で同様のサポートがあるなら、その利点や使い方、追跡方法についてのドキュメントを作成することをぜひお勧めします。
+
+異なるエディター向けにこうしたコメントが私たちのコードベースに広がることへの懸念は妥当なものであり、私たちは真剣に受け止めています。そのため、GitLab であまり活発に使われていない IDE のコメントを削除する議論を呼びかける Issue や、活発に保守／キュレーションされていないコード領域における JetBrains の `noinspection` コメントを削除する議論を呼びかける Issue を、チームメンバーが積極的にオープンすることを推奨しています。
+
+実際のところ、これらのコメントの `gitlab` コードベースにおける範囲は現在限定されています。[2023 年 7 月のこの MR](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/125831) 時点で、`Workspaces` ドメイン以外のすべての `noinspection` コメントはコードから削除されており、Workspaces はこれを積極的に活用している唯一のグループです。
+
+しかし、現在ではこのプロセスが標準化され、[JetBrains IDE の設定と利用に関するハンドブックのサポート](../setup-and-config/_index.md) も追加されたので、JetBrains を使う他のチームメンバーやチームもこのアプローチを採用したいと考えるかもしれません。

--- a/content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/_index.md
+++ b/content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/_index.md
@@ -1,0 +1,17 @@
+---
+title: "個別の IDE"
+simple_list: true
+upstream_path: /handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/
+upstream_sha: 6f672d050777a6a6cb33fc5f31ccf71ebdd5b812
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 個別の IDE
+
+JetBrains は、主要なソフトウェア開発プラットフォーム／エコシステム向けに [強力な統合開発環境(IDE) のスイート](https://www.jetbrains.com/products/) を提供しています。
+
+他のシングルアプリケーション型のエディターとは異なり、サポート対象のプラットフォーム／エコシステムごとに別個の個別 IDE アプリケーションが用意されています。
+
+GitLab で最もよく使われている個別の IDE は次のとおりです:

--- a/content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/goland.md
+++ b/content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/goland.md
@@ -1,0 +1,30 @@
+---
+title: "GoLand"
+upstream_path: /handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/goland/
+upstream_sha: 6f672d050777a6a6cb33fc5f31ccf71ebdd5b812
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 概要
+
+ウェブサイト: <https://www.jetbrains.com/go/>
+
+最適な用途: 主に Go で書かれたアプリケーション。
+
+## JetBrains 共通のセットアップと設定
+
+JetBrains の IDE は標準化されているため、セットアップと設定情報の多くはすべての IDE に共通して適用され、[JetBrains 共通のセットアップと設定](../setup-and-config/_index.md) で確認できます。
+
+GoLand 固有の設定は、以下のセクションを参照してください。
+
+## GoLand 固有のセットアップと設定
+
+### GoLand の設定
+
+- ここでは [mise](https://gitlab-org.gitlab.io/gitlab-development-kit/howto/mise/) 経由で `go` をインストール済みであることを前提としています。
+- `Go` セクションの設定:
+  - `GOROOT`
+    - `+` を押して `$HOME/.local/share/mise/installs/go/latest` を追加します
+    - 追加後、それを選択します。

--- a/content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/rubymine.md
+++ b/content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/rubymine.md
@@ -69,7 +69,7 @@ GitLab Workhorse と Puma がどのように協調動作するかの詳細につ
 
 まず ["GUI でデータベースにアクセスする"](https://docs.gitlab.com/ee/development/database/database_debugging.html#access-the-database-with-a-gui) の手順に従って、GDK 配下の postgresql を localhost で動作するよう再設定します。
 
-次に develoment データベースを設定します:
+次に development データベースを設定します:
 
 1. `File -> New -> Data Source -> Postgresql` に移動します（または右側の `Databases` タブから）
 1. 名前を入力: `gitlabhq_development@localhost`

--- a/content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/rubymine.md
+++ b/content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/rubymine.md
@@ -1,0 +1,100 @@
+---
+title: "RubyMine"
+upstream_path: /handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/rubymine/
+upstream_sha: 6f672d050777a6a6cb33fc5f31ccf71ebdd5b812
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 概要
+
+ウェブサイト: <https://www.jetbrains.com/ruby/>
+
+最適な用途: Ruby または Rails アプリケーション（Javascript/Typescript やその他のほとんどの Web 技術を含む可能性があります）の編集。
+
+## JetBrains 共通のセットアップと設定
+
+JetBrains の IDE は標準化されているため、セットアップと設定情報の多くはすべての IDE に共通して適用され、[JetBrains 共通のセットアップと設定](../setup-and-config/_index.md) で確認できます。
+
+RubyMine 固有の設定は、以下のセクションを参照してください。
+
+## GDK で動作する GitLab に対する Rubymine デバッガーの利用
+
+### `rails-web` のデバッグ
+
+#### Rails Puma バインディングについての注意
+
+デフォルトでは、GitLab が利用している Rails の [puma 設定テンプレートは TCP ポートではなくソケットにバインド](https://gitlab.com/gitlab-org/gitlab-development-kit/blob/d948d5485e3f519688783dc92ad70d94f132e396/support/templates/puma.rb.erb#L44) します。
+
+[このマージリクエスト](https://gitlab.com/gitlab-org/gitlab-development-kit/-/merge_requests/1693) により GDK で Rails puma を TCP ソケットにバインドする設定がサポートされ、また Workhorse が socket ではなく TCP ポートを使用するためのサポートが追加されました。さらに [この JetBrains の Issue](https://youtrack.jetbrains.com/issue/RUBY-27404) により、Run Configuration からソケットベースの Puma サーバーを起動するサポートが追加されました。
+
+GitLab Workhorse と Puma がどのように協調動作するかの詳細については、[コンポーネントに関するアーキテクチャドキュメント](https://docs.gitlab.com/ee/development/architecture.html#components) を参照してください。
+
+#### デフォルトのソケットバインディングを使う puma を使った RubyMine の "Ruby" Run Configuration を設定する
+
+1. デバッグセッションごとに、事前に `gdk stop rails-web` を実行しておいてください（デバッグ完了時には `gdk start rails-web` を実行）
+1. RubyMine で `/path/to/gdk/gitlab` にある gitlab リポジトリディレクトリを開きます（gitlab を別ディレクトリにクローンして実行しても、すぐには動作しません）
+1. `Run -> Edit Configurations` から、RubyMine 上で次のように Rails Run/Debug 設定を構成します:
+    - 名前: `GitLab: rails-web`
+    - 設定:
+      - Server: `Puma`
+      - IP address: 空欄（`0.0.0.0` を削除）
+      - Port: 空欄（`3000` を削除）
+      - Environment: `development`
+      - Environment Variables（注: 現在の GDK `Procfile` から取得した内容に加え、デバッグ中のタイムアウトを防ぐためのものを追加しています。古くなる可能性があります）:
+        - `RAILS_RELATIVE_URL_ROOT=/;ACTION_CABLE_IN_APP=true;ACTION_CABLE_WORKER_POOL_SIZE=4;FIPS_MODE=false;GEO_SECONDARY_PROXY=0;GITLAB_RAILS_RACK_TIMEOUT=999999;GITLAB_RAILS_WAIT_TIMEOUT=999999;GITALY_DISABLE_REQUEST_LIMITS=false;PUMA_WORKER_TIMEOUT=99999999`
+        - 注意: Procfile エントリの以下の値は不要なため省略しています:
+            - `BUNDLE_GEMFILE`
+            - `ENABLE_BOOTSNAP`
+            - `RAILS_ENV`
+1. Run（"Play" ▶️ ボタン）または Debug モード（右上）で設定を起動します
+
+### `rails-background-jobs` のデバッグ
+
+バックグラウンドジョブとして実行されるサービスをデバッグするには、`rails-web` デバッガーに加えて `rails-background-jobs` 用のデバッグも設定する必要があります。設定方法はほぼ同じですが、puma ではなく sidekiq プロセスに接続する点が異なります。
+
+1. デバッグセッションごとに、事前に `gdk stop rails-background-jobs` を実行しておいてください（デバッグ完了時には `gdk start rails-background-jobs` を実行）
+1. `Run -> Edit Configurations` から、RubyMine 上で次のように Ruby（Rails ではない）Run/Debug 設定を構成します:
+    - 名前: `GitLab: rails-background-jobs`
+    - Ruby Script: `/Users/YOUR_USER/.asdf/installs/ruby/RUBY_VERSION/bin/sidekiq`
+    - Working Directory: `/Users/YOUR_USER/PATH_TO/gitlab-development-kit/gitlab/`
+      - Environment Variables（注: 現在の GDK `Procfile` から取得しています。古くなる可能性があります）: `SIDEKIQ_VERBOSE=false;SIDEKIQ_QUEUES=default,mailers,email_receiver,hashed_storage:hashed_storage_migrator,hashed_storage:hashed_storage_project_migrate,hashed_storage:hashed_storage_project_rollback,hashed_storage:hashed_storage_rollbacker,project_import_schedule,service_desk_email_receiver;SIDEKIQ_WORKERS=1;RAILS_RELATIVE_URL_ROOT=/;GITALY_DISABLE_REQUEST_LIMITS=false`
+      - 注意: Procfile エントリの以下の値は不要なため省略しています:
+          - `BUNDLE_GEMFILE`
+          - `ENABLE_BOOTSNAP`
+          - `RAILS_ENV`
+
+## GDK のデータベース接続の設定
+
+まず ["GUI でデータベースにアクセスする"](https://docs.gitlab.com/ee/development/database/database_debugging.html#access-the-database-with-a-gui) の手順に従って、GDK 配下の postgresql を localhost で動作するよう再設定します。
+
+次に develoment データベースを設定します:
+
+1. `File -> New -> Data Source -> Postgresql` に移動します（または右側の `Databases` タブから）
+1. 名前を入力: `gitlabhq_development@localhost`
+1. Host: `localhost`
+1. Port: `5432`
+1. Authentication: `User & Password`
+1. User: 空欄のまま
+1. Password: デフォルトのまま、`<hidden>` と表示されます
+1. URL（上記フィールドから自動計算）: `jdbc:postgresql://localhost:5432/gitlabhq_development`
+1. 必要に応じてドライバーをダウンロードします。
+1. `Test Connection` をクリックします。
+
+その後、データベースにアクセスします:
+
+1. 右側のボーダーから `Databases` パネルを開きます
+1. リフレッシュボタン（円形矢印）をクリックします
+1. 展開してテーブル／ビュー／その他を確認します
+
+`config/database.yml` からさらにスキーマを追加したい場合:
+
+1. `Database` タブを開きます
+1. データベースの最上位を右クリックして `Properties` を表示します（または「レンチ」ボタン）
+1. `Schemas` タブを開きます
+1. 必要なスキーマを選択します。
+
+## その他
+
+- EE のコードに対して "Navigate to Test"（<kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>t</kbd>）を有効にするには、`ee/spec` ディレクトリを右クリックして "Mark Directory As..." → "Test Sources" を選択します。

--- a/content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/webstorm.md
+++ b/content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/webstorm.md
@@ -1,0 +1,24 @@
+---
+title: "Webstorm"
+upstream_path: /handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/webstorm/
+upstream_sha: 6f672d050777a6a6cb33fc5f31ccf71ebdd5b812
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 概要
+
+ウェブサイト: <https://www.jetbrains.com/webstorm/>
+
+最適な用途: Javascript/Typescript および node.js のアプリケーションや、その他の Web 技術。Ruby/Rails や JS/Typescript 以外の言語に基づくバックエンドを持たないものに向いています。
+
+## JetBrains 共通のセットアップと設定
+
+JetBrains の IDE は標準化されているため、セットアップと設定情報の多くはすべての IDE に共通して適用され、[JetBrains 共通のセットアップと設定](../setup-and-config/_index.md) で確認できます。
+
+WebStorm 固有の設定は、以下のセクションを参照してください。
+
+## WebStorm 固有のセットアップと設定
+
+将来のコンテンツ用のプレースホルダー…

--- a/content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/licenses/_index.md
+++ b/content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/licenses/_index.md
@@ -1,0 +1,27 @@
+---
+title: "ライセンス"
+no_list: true
+upstream_path: /handbook/tools-and-tips/editors-and-ides/jetbrains-ides/licenses/
+upstream_sha: 6f672d050777a6a6cb33fc5f31ccf71ebdd5b812
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## ライセンス
+
+GitLab 従業員向けに、JetBrains 製品の[ライセンス集中管理](https://www.jetbrains.com/help/license-vault-cloud/Introduction_to_License_Vault.html)が用意されています。
+
+1. 利用したい製品によっては、[Access Request](https://gitlab.com/gitlab-com/team-member-epics/access-requests) の申請が必要、または推奨される場合があります。
+    1. より大規模なユーザー群（5名以上）をオンボーディングしたい場合は、*必ず* Access Request を申請してください。
+    1. よく使われる JetBrains 製品（以下にリスト）を利用したい場合、Access Request の申請は *不要* です:
+        - GoLand、RubyMine、PyCharm、DataGrip、WebStorm
+        - Editor Extensions の作業を行う場合は IntelliJ IDEA Ultimate
+    1. その他の JetBrains 製品を利用したい場合:
+        - *日常的に* 利用する場合は、*必ず* Access Request を申請してください。
+        - *時々の利用* であれば Access Request なしでも可能です。「All Products」ライセンスは数に限りがありますので、Access Request を申請した方は、時々の利用者よりも優先的に取り扱われることに注意してください。
+1. Access Request が処理待ちの状態でも、[ご自身のライセンスをアクティベート](https://www.jetbrains.com/help/license-vault-cloud/Activating_a_license.html)できます。
+    - アクティベーション時はライセンスサーバー URL `https://gitlab.fls.jetbrains.com` を使用してください
+    - 認証には必ず Okta 経由でログインしてください
+
+ご自身で取得した個人ライセンスをお持ちの場合、それは[一般的な商用利用](https://www.jetbrains.com/store/comparison.html#LicenseComparison)に適しており、利用しても問題ありません。ただし、個人ライセンスは企業によって購入も払い戻しもできないため、GitLab は個人ライセンスの払い戻しは行いません。とはいえ、これまで個人ライセンスを利用していた方も、いつでも会社発行のライセンスをリクエストできます。

--- a/translation-state/manifest.json
+++ b/translation-state/manifest.json
@@ -16476,26 +16476,229 @@
       "model": "claude-opus-4-7",
       "input_hash": "ebb3e4a36116fddfde2cd2ad19f80fbaccd4a1a5777234c6840d079dcafe19ef"
     },
-    "content/handbook/values/_index.md": {
-      "path": "content/handbook/values/_index.md",
-      "upstream_sha": "d0d8657a733d2233820b2b00aaad27ebf5de9755",
-      "translated_at": "2026-05-07T00:00:00Z",
+    "content/handbook/tools-and-tips/_index.md": {
+      "path": "content/handbook/tools-and-tips/_index.md",
+      "upstream_sha": "23c2fc5bd7f24c010a605fa6c69802a42ed0cfd0",
+      "translated_at": "2026-05-07T22:45:00Z",
       "model": "claude-opus-4-7",
-      "input_hash": "4cc995ac89293b07dfa4061d70ebcf334ecd989f0239cf0ca9acd0e6c742ca57"
+      "input_hash": "0c796c956f6b6c92f8f3d43a7638e77994447216488913bf8e0d1bab67ebdd1f"
     },
-    "content/handbook/upstream-studios/_index.md": {
-      "path": "content/handbook/upstream-studios/_index.md",
-      "upstream_sha": "d0d8657a733d2233820b2b00aaad27ebf5de9755",
-      "translated_at": "2026-05-07T00:00:00Z",
+    "content/handbook/tools-and-tips/ai/_index.md": {
+      "path": "content/handbook/tools-and-tips/ai/_index.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
       "model": "claude-opus-4-7",
-      "input_hash": "87636fb092b79ca9122d7711a36a6ed4221537f11be8fb7fda8f5b8a7d62994d"
+      "input_hash": "75c66ef2e6afdbff1398d680106648f1aedf7ed9fe95b47a3dedd0ef0000ca12"
     },
-    "content/handbook/upstream-studios/vision-strategy/_index.md": {
-      "path": "content/handbook/upstream-studios/vision-strategy/_index.md",
-      "upstream_sha": "d0d8657a733d2233820b2b00aaad27ebf5de9755",
-      "translated_at": "2026-05-07T00:00:00Z",
+    "content/handbook/tools-and-tips/ai/claude.md": {
+      "path": "content/handbook/tools-and-tips/ai/claude.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
       "model": "claude-opus-4-7",
-      "input_hash": "47855f5c06dbff45da994e914becacb9dba10e00f1c34198f5670b1924f9df73"
+      "input_hash": "c96df0244f8520912700b491d19de53dff49e40b0203aba37028ac37034c7249"
+    },
+    "content/handbook/tools-and-tips/ai/gitlab-duo.md": {
+      "path": "content/handbook/tools-and-tips/ai/gitlab-duo.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "863ae36f2635dfa0f86c1158ab24eb173dfbf2358536d339db8720fa9f83e98e"
+    },
+    "content/handbook/tools-and-tips/editors-and-ides/_index.md": {
+      "path": "content/handbook/tools-and-tips/editors-and-ides/_index.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "99bd50f2fa423e80a6c7703dc4f18f135bd03e4a3d03c4f8a9754ebde8d1a6bc"
+    },
+    "content/handbook/tools-and-tips/editors-and-ides/emacs.md": {
+      "path": "content/handbook/tools-and-tips/editors-and-ides/emacs.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "9ff4e395ad5dca8b1537485b006c32c6a5238ba2170bbecb709a20bab11a93b7"
+    },
+    "content/handbook/tools-and-tips/editors-and-ides/gitlab-web-ide.md": {
+      "path": "content/handbook/tools-and-tips/editors-and-ides/gitlab-web-ide.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "763c3860d1c9020ea84c34780082dbf5fea95e90676e354ffbbc5b4f0aab81bf"
+    },
+    "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/_index.md": {
+      "path": "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/_index.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "9cca9ce5a6d0aa4dac3ae978839e2a675049a67cbd999d695698bc2b47f0e72b"
+    },
+    "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/code-inspection/_index.md": {
+      "path": "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/code-inspection/_index.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "7cae242547c725186870564b5058127ba9dddb0d466555843f9dcf783698abc8"
+    },
+    "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/code-inspection/why-are-there-noinspection-comments.md": {
+      "path": "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/code-inspection/why-are-there-noinspection-comments.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "1e27d4f7da9632111ccc93e63381cef06abfa201c29832e90ea2bfe03ff61c42"
+    },
+    "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/_index.md": {
+      "path": "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/_index.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "5fcf3c225e9ed200ca9b534dc3c4076bb9da149c4382cb8c266a006bdb0cc5ce"
+    },
+    "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/goland.md": {
+      "path": "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/goland.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "f38217903b8407b19079c89e54ee59ec085c10534e801867988fa2e61fa78bea"
+    },
+    "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/rubymine.md": {
+      "path": "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/rubymine.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "e8f09e6e4a78e63f7532ce8e89888cffa1adc257f2870432c1f3c32a4eeb60a8"
+    },
+    "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/webstorm.md": {
+      "path": "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/webstorm.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "00e7b9b8d8c08c4fa853b1aa92539115522f34b3a08a5b86cd7b25625cf84916"
+    },
+    "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/licenses/_index.md": {
+      "path": "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/licenses/_index.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "57f95d1fc3b91078230870e714f7303df8daf8c431c5599982758bc4c87f5762"
+    },
+    "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/setup-and-config/_index.md": {
+      "path": "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/setup-and-config/_index.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "ed4545d22e5c0e2bbadc11d6b9f91d821d8afdb936a96814fc603c190c1ec519"
+    },
+    "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/tracked-jetbrains-issues/_index.md": {
+      "path": "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/tracked-jetbrains-issues/_index.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "21e74538db35d046a2d5251bba6040776ade8236c5f9dbc62839e7564c8b4b66"
+    },
+    "content/handbook/tools-and-tips/editors-and-ides/sublime-text.md": {
+      "path": "content/handbook/tools-and-tips/editors-and-ides/sublime-text.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "40f7f754892cf7377ff5cf9154bffa257199a531d969e6bcb2de4af8227da1c2"
+    },
+    "content/handbook/tools-and-tips/editors-and-ides/vim.md": {
+      "path": "content/handbook/tools-and-tips/editors-and-ides/vim.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "237c1765a60ac1793ddc14361bfb1cba22f598c0f108abe333b95f5c9d7e2c5e"
+    },
+    "content/handbook/tools-and-tips/editors-and-ides/visual-studio-code.md": {
+      "path": "content/handbook/tools-and-tips/editors-and-ides/visual-studio-code.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "f2653e3f92b8867b9be18bed04fbf0b90cef2b2ecd57e67a0ac3343c49ae1416"
+    },
+    "content/handbook/tools-and-tips/git.md": {
+      "path": "content/handbook/tools-and-tips/git.md",
+      "upstream_sha": "23c2fc5bd7f24c010a605fa6c69802a42ed0cfd0",
+      "translated_at": "2026-05-07T22:45:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "9b738b4e68a831b2b97b8dfd7fd4898f3429d420cd55b47c97223b4587443c7d"
+    },
+    "content/handbook/tools-and-tips/linux.md": {
+      "path": "content/handbook/tools-and-tips/linux.md",
+      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
+      "translated_at": "2026-05-07T15:33:18Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "b2b959abb1ae0018b7c603812de9ab29eb6d922c155b30378842848a6b2998b8"
+    },
+    "content/handbook/tools-and-tips/mac.md": {
+      "path": "content/handbook/tools-and-tips/mac.md",
+      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
+      "translated_at": "2026-05-07T15:33:18Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "4fcc86d0aff07fa35381e69d941b95e296209f3e9282984b7737b2bc476b1b22"
+    },
+    "content/handbook/tools-and-tips/mermaid.md": {
+      "path": "content/handbook/tools-and-tips/mermaid.md",
+      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
+      "translated_at": "2026-05-07T15:33:18Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "af2b33ed99cb9439188a3b9e3ed530bfec1100185133c258e37ba7032f2085cb"
+    },
+    "content/handbook/tools-and-tips/onepassword-cli.md": {
+      "path": "content/handbook/tools-and-tips/onepassword-cli.md",
+      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
+      "translated_at": "2026-05-07T15:33:18Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "7c6a8b8c944551cf4eaeec97dce6c5f7a07387b2e99951f539d5aaf16bfe9d99"
+    },
+    "content/handbook/tools-and-tips/other-apps.md": {
+      "path": "content/handbook/tools-and-tips/other-apps.md",
+      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
+      "translated_at": "2026-05-07T15:33:18Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "9dcd6aed3a02e71d5bf7c674b25e1947659bb73fa5f6e16b5a525854a4408d0b"
+    },
+    "content/handbook/tools-and-tips/personal-vpn.md": {
+      "path": "content/handbook/tools-and-tips/personal-vpn.md",
+      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
+      "translated_at": "2026-05-07T15:33:18Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "757784d4f3daadc3195db6747b33e0eaaa5d4fb98c22bdc80e263ac2fa584e96"
+    },
+    "content/handbook/tools-and-tips/rubocop.md": {
+      "path": "content/handbook/tools-and-tips/rubocop.md",
+      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
+      "translated_at": "2026-05-07T15:33:18Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "aced50b5f73bac4eaa9f00e1b68f31639153ed84afe085bf22a20afbdbd3c0f8"
+    },
+    "content/handbook/tools-and-tips/searching/_index.md": {
+      "path": "content/handbook/tools-and-tips/searching/_index.md",
+      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
+      "translated_at": "2026-05-07T15:33:18Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "1c3fff6915cb848344b4753418b1bc5c8ae26211d41b65de3267ad7c0c49bff5"
+    },
+    "content/handbook/tools-and-tips/searching/gitlab-keyword-search-firefox-bookmarks.md": {
+      "path": "content/handbook/tools-and-tips/searching/gitlab-keyword-search-firefox-bookmarks.md",
+      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "61e8edfe8a434abdec10c127f73d53d6965a5b62105d8bb1f5e976ffa5674cd1"
+    },
+    "content/handbook/tools-and-tips/slack.md": {
+      "path": "content/handbook/tools-and-tips/slack.md",
+      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
+      "translated_at": "2026-05-07T15:33:18Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "10e2c86c8b5f7547173644ce73cf4e2a99c12737bf64958249edc5d28559b0a4"
+    },
+    "content/handbook/tools-and-tips/zoom.md": {
+      "path": "content/handbook/tools-and-tips/zoom.md",
+      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
+      "translated_at": "2026-05-07T15:33:18Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "af7d8d3cda89a3b5288e5ed004e490746b7dc2a012202e2ec3a39a80c6fdb937"
     },
     "content/handbook/total-rewards/_index.md": {
       "path": "content/handbook/total-rewards/_index.md",
@@ -16504,54 +16707,12 @@
       "model": "claude-opus-4-7",
       "input_hash": "5379feb4cd434b92f512618122a57d970f7ea77a86d772949f1357c4edede3cf"
     },
-    "content/handbook/total-rewards/incentives.md": {
-      "path": "content/handbook/total-rewards/incentives.md",
-      "upstream_sha": "d0d8657a733d2233820b2b00aaad27ebf5de9755",
-      "translated_at": "2026-05-07T00:00:00Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "29c23f75c4d69fe0eb31ca222494df32984147c0cec3382073c08883a515a8de"
-    },
-    "content/handbook/total-rewards/stock-options.md": {
-      "path": "content/handbook/total-rewards/stock-options.md",
-      "upstream_sha": "d0d8657a733d2233820b2b00aaad27ebf5de9755",
-      "translated_at": "2026-05-07T00:00:00Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "ce62cd564e06a522d5f64eb11e534f4d378ff62f36b6c724ea7f084be1b6d606"
-    },
-    "content/handbook/total-rewards/compensation/_index.md": {
-      "path": "content/handbook/total-rewards/compensation/_index.md",
-      "upstream_sha": "d0d8657a733d2233820b2b00aaad27ebf5de9755",
-      "translated_at": "2026-05-07T00:00:00Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "3384141e5c1fb956522d5c627df2a5350cb59d720661a9342f7319a1f1dbad7e"
-    },
-    "content/handbook/total-rewards/compensation/compensation-review-cycle/_index.md": {
-      "path": "content/handbook/total-rewards/compensation/compensation-review-cycle/_index.md",
-      "upstream_sha": "d0d8657a733d2233820b2b00aaad27ebf5de9755",
-      "translated_at": "2026-05-07T00:00:00Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "54b0adad0897f59da2dd191a35c18eaa607069d9debbe97686840363abc4ebde"
-    },
     "content/handbook/total-rewards/benefits/_index.md": {
       "path": "content/handbook/total-rewards/benefits/_index.md",
       "upstream_sha": "d0d8657a733d2233820b2b00aaad27ebf5de9755",
       "translated_at": "2026-05-07T00:00:00Z",
       "model": "claude-opus-4-7",
       "input_hash": "93fe96ec49c01e94e5bda1c999d2cec9b45c253870e045767fa9f96438125062"
-    },
-    "content/handbook/total-rewards/benefits/modern-health.md": {
-      "path": "content/handbook/total-rewards/benefits/modern-health.md",
-      "upstream_sha": "d0d8657a733d2233820b2b00aaad27ebf5de9755",
-      "translated_at": "2026-05-07T00:00:00Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "246f22b96e7b0bae695b118e89e71a014b69cc29ad67343d9e39b92d19ba7635"
-    },
-    "content/handbook/total-rewards/benefits/parental-leave-toolkit.md": {
-      "path": "content/handbook/total-rewards/benefits/parental-leave-toolkit.md",
-      "upstream_sha": "9bd896709582cfb6bccdb0d721755db917231bc6",
-      "translated_at": "2026-05-07T13:21:11Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "b9a0f392ec5f954de59d53e965a42930f05c0323755449fb5917377167f95a1a"
     },
     "content/handbook/total-rewards/benefits/general-and-entity-benefits/_index.md": {
       "path": "content/handbook/total-rewards/benefits/general-and-entity-benefits/_index.md",
@@ -16672,159 +16833,68 @@
       "model": "claude-opus-4-7",
       "input_hash": "0cc61cb79f32a1f58f781248a6dcd8c9ad3b33167cbb41ba1750d59177ba092c"
     },
-    "content/handbook/tools-and-tips/_index.md": {
-      "path": "content/handbook/tools-and-tips/_index.md",
-      "upstream_sha": "23c2fc5bd7f24c010a605fa6c69802a42ed0cfd0",
-      "translated_at": "2026-05-07T22:45:00Z",
+    "content/handbook/total-rewards/benefits/modern-health.md": {
+      "path": "content/handbook/total-rewards/benefits/modern-health.md",
+      "upstream_sha": "d0d8657a733d2233820b2b00aaad27ebf5de9755",
+      "translated_at": "2026-05-07T00:00:00Z",
       "model": "claude-opus-4-7",
-      "input_hash": "0c796c956f6b6c92f8f3d43a7638e77994447216488913bf8e0d1bab67ebdd1f"
+      "input_hash": "246f22b96e7b0bae695b118e89e71a014b69cc29ad67343d9e39b92d19ba7635"
     },
-    "content/handbook/tools-and-tips/git.md": {
-      "path": "content/handbook/tools-and-tips/git.md",
-      "upstream_sha": "23c2fc5bd7f24c010a605fa6c69802a42ed0cfd0",
-      "translated_at": "2026-05-07T22:45:00Z",
+    "content/handbook/total-rewards/benefits/parental-leave-toolkit.md": {
+      "path": "content/handbook/total-rewards/benefits/parental-leave-toolkit.md",
+      "upstream_sha": "9bd896709582cfb6bccdb0d721755db917231bc6",
+      "translated_at": "2026-05-07T13:21:11Z",
       "model": "claude-opus-4-7",
-      "input_hash": "9b738b4e68a831b2b97b8dfd7fd4898f3429d420cd55b47c97223b4587443c7d"
+      "input_hash": "b9a0f392ec5f954de59d53e965a42930f05c0323755449fb5917377167f95a1a"
     },
-    "content/handbook/tools-and-tips/linux.md": {
-      "path": "content/handbook/tools-and-tips/linux.md",
-      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
-      "translated_at": "2026-05-07T15:33:18Z",
+    "content/handbook/total-rewards/compensation/_index.md": {
+      "path": "content/handbook/total-rewards/compensation/_index.md",
+      "upstream_sha": "d0d8657a733d2233820b2b00aaad27ebf5de9755",
+      "translated_at": "2026-05-07T00:00:00Z",
       "model": "claude-opus-4-7",
-      "input_hash": "b2b959abb1ae0018b7c603812de9ab29eb6d922c155b30378842848a6b2998b8"
+      "input_hash": "3384141e5c1fb956522d5c627df2a5350cb59d720661a9342f7319a1f1dbad7e"
     },
-    "content/handbook/tools-and-tips/mac.md": {
-      "path": "content/handbook/tools-and-tips/mac.md",
-      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
-      "translated_at": "2026-05-07T15:33:18Z",
+    "content/handbook/total-rewards/compensation/compensation-review-cycle/_index.md": {
+      "path": "content/handbook/total-rewards/compensation/compensation-review-cycle/_index.md",
+      "upstream_sha": "d0d8657a733d2233820b2b00aaad27ebf5de9755",
+      "translated_at": "2026-05-07T00:00:00Z",
       "model": "claude-opus-4-7",
-      "input_hash": "4fcc86d0aff07fa35381e69d941b95e296209f3e9282984b7737b2bc476b1b22"
+      "input_hash": "54b0adad0897f59da2dd191a35c18eaa607069d9debbe97686840363abc4ebde"
     },
-    "content/handbook/tools-and-tips/mermaid.md": {
-      "path": "content/handbook/tools-and-tips/mermaid.md",
-      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
-      "translated_at": "2026-05-07T15:33:18Z",
+    "content/handbook/total-rewards/incentives.md": {
+      "path": "content/handbook/total-rewards/incentives.md",
+      "upstream_sha": "d0d8657a733d2233820b2b00aaad27ebf5de9755",
+      "translated_at": "2026-05-07T00:00:00Z",
       "model": "claude-opus-4-7",
-      "input_hash": "af2b33ed99cb9439188a3b9e3ed530bfec1100185133c258e37ba7032f2085cb"
+      "input_hash": "29c23f75c4d69fe0eb31ca222494df32984147c0cec3382073c08883a515a8de"
     },
-    "content/handbook/tools-and-tips/onepassword-cli.md": {
-      "path": "content/handbook/tools-and-tips/onepassword-cli.md",
-      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
-      "translated_at": "2026-05-07T15:33:18Z",
+    "content/handbook/total-rewards/stock-options.md": {
+      "path": "content/handbook/total-rewards/stock-options.md",
+      "upstream_sha": "d0d8657a733d2233820b2b00aaad27ebf5de9755",
+      "translated_at": "2026-05-07T00:00:00Z",
       "model": "claude-opus-4-7",
-      "input_hash": "7c6a8b8c944551cf4eaeec97dce6c5f7a07387b2e99951f539d5aaf16bfe9d99"
+      "input_hash": "ce62cd564e06a522d5f64eb11e534f4d378ff62f36b6c724ea7f084be1b6d606"
     },
-    "content/handbook/tools-and-tips/other-apps.md": {
-      "path": "content/handbook/tools-and-tips/other-apps.md",
-      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
-      "translated_at": "2026-05-07T15:33:18Z",
+    "content/handbook/upstream-studios/_index.md": {
+      "path": "content/handbook/upstream-studios/_index.md",
+      "upstream_sha": "d0d8657a733d2233820b2b00aaad27ebf5de9755",
+      "translated_at": "2026-05-07T00:00:00Z",
       "model": "claude-opus-4-7",
-      "input_hash": "9dcd6aed3a02e71d5bf7c674b25e1947659bb73fa5f6e16b5a525854a4408d0b"
+      "input_hash": "87636fb092b79ca9122d7711a36a6ed4221537f11be8fb7fda8f5b8a7d62994d"
     },
-    "content/handbook/tools-and-tips/personal-vpn.md": {
-      "path": "content/handbook/tools-and-tips/personal-vpn.md",
-      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
-      "translated_at": "2026-05-07T15:33:18Z",
+    "content/handbook/upstream-studios/vision-strategy/_index.md": {
+      "path": "content/handbook/upstream-studios/vision-strategy/_index.md",
+      "upstream_sha": "d0d8657a733d2233820b2b00aaad27ebf5de9755",
+      "translated_at": "2026-05-07T00:00:00Z",
       "model": "claude-opus-4-7",
-      "input_hash": "757784d4f3daadc3195db6747b33e0eaaa5d4fb98c22bdc80e263ac2fa584e96"
+      "input_hash": "47855f5c06dbff45da994e914becacb9dba10e00f1c34198f5670b1924f9df73"
     },
-    "content/handbook/tools-and-tips/rubocop.md": {
-      "path": "content/handbook/tools-and-tips/rubocop.md",
-      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
-      "translated_at": "2026-05-07T15:33:18Z",
+    "content/handbook/values/_index.md": {
+      "path": "content/handbook/values/_index.md",
+      "upstream_sha": "d0d8657a733d2233820b2b00aaad27ebf5de9755",
+      "translated_at": "2026-05-07T00:00:00Z",
       "model": "claude-opus-4-7",
-      "input_hash": "aced50b5f73bac4eaa9f00e1b68f31639153ed84afe085bf22a20afbdbd3c0f8"
-    },
-    "content/handbook/tools-and-tips/searching/_index.md": {
-      "path": "content/handbook/tools-and-tips/searching/_index.md",
-      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
-      "translated_at": "2026-05-07T15:33:18Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "1c3fff6915cb848344b4753418b1bc5c8ae26211d41b65de3267ad7c0c49bff5"
-    },
-    "content/handbook/tools-and-tips/searching/gitlab-keyword-search-firefox-bookmarks.md": {
-      "path": "content/handbook/tools-and-tips/searching/gitlab-keyword-search-firefox-bookmarks.md",
-      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
-      "translated_at": "2026-05-08T00:00:00Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "61e8edfe8a434abdec10c127f73d53d6965a5b62105d8bb1f5e976ffa5674cd1"
-    },
-    "content/handbook/tools-and-tips/editors-and-ides/_index.md": {
-      "path": "content/handbook/tools-and-tips/editors-and-ides/_index.md",
-      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
-      "translated_at": "2026-05-08T00:00:00Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "99bd50f2fa423e80a6c7703dc4f18f135bd03e4a3d03c4f8a9754ebde8d1a6bc"
-    },
-    "content/handbook/tools-and-tips/editors-and-ides/emacs.md": {
-      "path": "content/handbook/tools-and-tips/editors-and-ides/emacs.md",
-      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
-      "translated_at": "2026-05-08T00:00:00Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "9ff4e395ad5dca8b1537485b006c32c6a5238ba2170bbecb709a20bab11a93b7"
-    },
-    "content/handbook/tools-and-tips/editors-and-ides/gitlab-web-ide.md": {
-      "path": "content/handbook/tools-and-tips/editors-and-ides/gitlab-web-ide.md",
-      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
-      "translated_at": "2026-05-08T00:00:00Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "763c3860d1c9020ea84c34780082dbf5fea95e90676e354ffbbc5b4f0aab81bf"
-    },
-    "content/handbook/tools-and-tips/editors-and-ides/sublime-text.md": {
-      "path": "content/handbook/tools-and-tips/editors-and-ides/sublime-text.md",
-      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
-      "translated_at": "2026-05-08T00:00:00Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "40f7f754892cf7377ff5cf9154bffa257199a531d969e6bcb2de4af8227da1c2"
-    },
-    "content/handbook/tools-and-tips/editors-and-ides/vim.md": {
-      "path": "content/handbook/tools-and-tips/editors-and-ides/vim.md",
-      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
-      "translated_at": "2026-05-08T00:00:00Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "237c1765a60ac1793ddc14361bfb1cba22f598c0f108abe333b95f5c9d7e2c5e"
-    },
-    "content/handbook/tools-and-tips/editors-and-ides/visual-studio-code.md": {
-      "path": "content/handbook/tools-and-tips/editors-and-ides/visual-studio-code.md",
-      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
-      "translated_at": "2026-05-08T00:00:00Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "f2653e3f92b8867b9be18bed04fbf0b90cef2b2ecd57e67a0ac3343c49ae1416"
-    },
-    "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/_index.md": {
-      "path": "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/_index.md",
-      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
-      "translated_at": "2026-05-08T00:00:00Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "9cca9ce5a6d0aa4dac3ae978839e2a675049a67cbd999d695698bc2b47f0e72b"
-    },
-    "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/tracked-jetbrains-issues/_index.md": {
-      "path": "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/tracked-jetbrains-issues/_index.md",
-      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
-      "translated_at": "2026-05-08T00:00:00Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "21e74538db35d046a2d5251bba6040776ade8236c5f9dbc62839e7564c8b4b66"
-    },
-    "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/setup-and-config/_index.md": {
-      "path": "content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/setup-and-config/_index.md",
-      "upstream_sha": "6f672d050777a6a6cb33fc5f31ccf71ebdd5b812",
-      "translated_at": "2026-05-08T00:00:00Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "ed4545d22e5c0e2bbadc11d6b9f91d821d8afdb936a96814fc603c190c1ec519"
-    },
-    "content/handbook/tools-and-tips/slack.md": {
-      "path": "content/handbook/tools-and-tips/slack.md",
-      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
-      "translated_at": "2026-05-07T15:33:18Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "10e2c86c8b5f7547173644ce73cf4e2a99c12737bf64958249edc5d28559b0a4"
-    },
-    "content/handbook/tools-and-tips/zoom.md": {
-      "path": "content/handbook/tools-and-tips/zoom.md",
-      "upstream_sha": "68af60af15ea4dcb51c3d985f7473b212e4f2cb4",
-      "translated_at": "2026-05-07T15:33:18Z",
-      "model": "claude-opus-4-7",
-      "input_hash": "af7d8d3cda89a3b5288e5ed004e490746b7dc2a012202e2ec3a39a80c6fdb937"
+      "input_hash": "4cc995ac89293b07dfa4061d70ebcf334ecd989f0239cf0ca9acd0e6c742ca57"
     }
   }
 }


### PR DESCRIPTION
## Summary
- 10 ファイルを翻訳・追加（jetbrains-ides 配下 + tools-and-tips/ai セクション開始）
- upstream SHA: \`6f672d050777a6a6cb33fc5f31ccf71ebdd5b812\`
- translator サブエージェント (\`.claude/agents/translator.md\`) で生成、\`translation-state/manifest.json\` を更新済み
- このPRは #106 を base にしているので、先行PRが順にマージされたら自動で main に rebase されます

## 翻訳ファイル
- \`content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/licenses/_index.md\`
- \`content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/_index.md\`
- \`content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/goland.md\`
- \`content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/rubymine.md\`
- \`content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/individual-ides/webstorm.md\`
- \`content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/code-inspection/_index.md\`
- \`content/handbook/tools-and-tips/editors-and-ides/jetbrains-ides/code-inspection/why-are-there-noinspection-comments.md\`
- \`content/handbook/tools-and-tips/ai/_index.md\`
- \`content/handbook/tools-and-tips/ai/claude.md\`
- \`content/handbook/tools-and-tips/ai/gitlab-duo.md\`

## 注記
- \`translation-state/manifest.json\` のエントリがキー順にソートされたため、追加 10 件以外にも行入れ替えの差分が含まれます

## Test plan
- [x] \`hugo --renderToMemory\` クリーン（キャッシュ削除後）、エラー 0 件
- [ ] CodeRabbit レビュー対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新規ドキュメント**
  * AI活用ガイドを追加：Claude と GitLab Duo の利用方法、プロンプト例、トラブルシューティング
  * JetBrains IDE ガイドを拡充：GoLand、RubyMine、WebStorm のセットアップと設定手順
  * コードインスペクション機能の運用ガイドを新規追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->