### PR TITLE
translation: 10 handbook support-pods subsection pages (ai/auth/cicd/code/db/docs/geo/get/git-gitaly/ssc-mbr)

### DIFF
--- a/content/handbook/support/support-pods/ai/_index.md
+++ b/content/handbook/support/support-pods/ai/_index.md
@@ -1,0 +1,78 @@
+---
+title: AI サポート Pod
+description: サポートエンジニアが Duo のチケットで協働し、AI を活用してサポートのワークフローを改善するための場です。
+upstream_path: /handbook/support/support-pods/ai/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 目的
+
+- サポートエンジニアが Duo のチケットで協働できる場を提供する
+- Duo の機能について最新情報を把握し、専門知識を深める
+- AI を活用してサポートのワークフローを改善する方法を特定し、テストする
+
+## スコープ
+
+この Pod のトピックは、できる限り次の製品グループと整合させます。
+
+- [AI-Powered ステージ](/handbook/product/categories/#ai-powered-stage) のすべてのグループ
+  - [AI Coding](/handbook/product/categories/#ai-coding-group)
+  - [AI Framework](/handbook/product/categories/#ai-framework-group)
+  - [Custom Models](/handbook/product/categories/#custom-models-group)
+  - [Duo Chat](/handbook/product/categories/#duo-chat-group)
+  - [Editor Extensions](/handbook/product/categories/#editor-extensions-group)
+
+AI（できれば Duo のドッグフーディング）でサポートのワークフローを改善する取り組みも、この Pod で議論・推進されます。
+
+## 現在の目標
+
+- すべてのリージョンが参加できる定例ミーティングを継続する
+- Duo に関するすべてに関して最新情報を把握する
+- Duo のチケットでお互いを助け合う！
+- AI を活用したサポートワークフローの改善を推進・議論・テストする
+
+## サポート Pod のメンバー
+
+- リード: {{< member-by-name "Łukasz Korbasiewicz" >}} (`@lkorbasiewicz`)
+- {{< member-by-name "Duncan Harris" >}} (`@duncan_harris`)
+- {{< member-by-name "Edward Hilgendorf IV" >}} (`@edward`)
+- {{< member-by-name "Luminus Alabi" >}} (`@lalabi`)
+- {{< member-by-name "Simon Howlett" >}} (`@showlett1`)
+- {{< member-by-name "John Gaughan" >}} (`@jgaughan`)
+
+## 参加方法
+
+1. マネージャーと話す。
+1. [Support Team データ](https://gitlab.com/gitlab-support-readiness/support-team/-/tree/master/data/agents?ref_type=heads) の自分の knowledge areas に Duo を追加する。すでに存在する場合は、レベルをそれに応じて調整する。
+1. チームメイトとグループメイトに新しい注力分野について伝える。
+1. [#spt_pod_ai](https://gitlab.enterprise.slack.com/archives/C06KMDBJT5F) Slack チャネルに参加する。
+1. このページに自分を追加する。
+1. AI ペアリングセッションに参加する。[定例ミーティング](#regular-meetings) を参照し、最新のミーティング時刻については GitLab Support カレンダーを確認してください
+
+## 定例ミーティング {#regular-meetings}
+
+- AI Pod ペアリングセッション:
+  - EMEA & AMER 向け: 火曜、DST により 13:00 / 14:00 UTC（GitLab Support カレンダー参照）
+  - AMER & APAC 向け: 木曜、DST により 22:00 / 23:00 UTC（GitLab Support カレンダー参照）
+- Duo Powered Pairing
+  - EMEA 向け: 金曜、DST により 11:00 / 12:00 UTC（GitLab Support カレンダー参照）
+
+## Slack チャネル
+
+- AI サポート Pod の Slack チャネル: [#spt_pod_ai](https://gitlab.enterprise.slack.com/archives/C06KMDBJT5F)
+
+その他の関心のある Slack チャネル:
+
+- [#ai_reading_feed](https://gitlab.enterprise.slack.com/archives/C06RXQR3TGF)
+- [#ai_strategy](https://gitlab.enterprise.slack.com/archives/C051V1CHBFE)
+- [#ai-field-strategy](https://gitlab.enterprise.slack.com/archives/C051SLP8WNB)
+- [#duo-chat-feature-flag-request](https://gitlab.enterprise.slack.com/archives/C070FUQ7JDN)
+- [#f_code-suggestions](https://gitlab.enterprise.slack.com/archives/C06841NNQNS)
+- [#cloud-connector-lounge](https://gitlab.enterprise.slack.com/archives/C04KWTK3GFJ)
+- [#duo-chat-lounge](https://gitlab.enterprise.slack.com/archives/C06LWENL58F)
+- [#g_ai_framework](https://gitlab.enterprise.slack.com/archives/C051K31F30R)
+- [#g_ai_model_validation](https://gitlab.enterprise.slack.com/archives/C05CJ1T3P0W)
+- [#g_duo_chat](https://gitlab.enterprise.slack.com/archives/C06D5C70MD2)

--- a/content/handbook/support/support-pods/authentication-and-authorization/_index.md
+++ b/content/handbook/support/support-pods/authentication-and-authorization/_index.md
@@ -1,0 +1,63 @@
+---
+title: 認証および認可サポート Pod
+description: OmniAuth、SAML、SCIM、LDAP、その他の認証関連事項のチケットで協働します。
+upstream_path: /handbook/support/support-pods/authentication-and-authorization/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 目的
+
+EMEA で行われている SAML スタディグループを補完し、異なるリージョンのチケットで協働するための時間を確保することで、他の OAuth プロバイダーに関する知識を深め、リージョンを越えて知識を共有できるようにします。
+
+## 現在の目標
+
+- OmniAuth、SAML、SCIM、LDAP、その他の認証関連事項のチケットで協働する
+
+- さまざまなセットアップを試したり再現したりする
+
+- 知識の獲得と共有
+
+- ドキュメントの更新
+
+## サポート Pod のメンバー
+
+- リード: {{< member-by-name "Asmaa Hassan Ahmed Ali" >}} (`@asmaa.hassan`)
+- リード: {{< member-by-name "Gerardo Gutierrez" >}} (`@gerardo`)
+- リード: {{< member-by-name "Jio Castillo" >}} (`@j.castillo`)
+- リード: {{< member-by-name "Alejandro Guerrero de Alba" >}} (`@alejguer`)
+- {{< member-by-name "Sabine Carpenter" >}} (`@sabinecarpenter`)
+- {{< member-by-name "Firdaws Farukh" >}} (`@ffarukh`)
+- {{< member-by-name "Tristan Williams" >}} (`@tristan`)
+- {{< member-by-name "Michael Gibson" >}} (`@mgibsongl`)
+- {{< member-by-name "Austin Pierce" >}} (`@Austin_Pierce`)
+- {{< member-by-name "Michael Lussier" >}} (`@m_lussier`)
+- {{< member-by-name "Daphne Kua" >}} (`@dkua1`)
+- {{< member-by-name "Armin Hergenhan" >}} (`@ahergenhan`)
+- {{< member-by-name "Bruno Freitas" >}} (`@bfreitas`)
+- {{< member-by-name "Chris Stone" >}} (`@cms`)
+- {{< member-by-name "Brie Carranza" >}} (`@bcarranza`)
+
+## コラボレーションチャネル
+
+- [#spt_pod_auth](https://gitlab.slack.com/archives/C01NGKZQ2F2) Slack チャネル
+- 隔週ミーティング:
+  - APAC/EMEA 向け: 隔週火曜 9 AM UTC
+  - EMEA/AMER 向け: 隔週火曜 1 PM UTC
+  - AMER/APAC 向け: 月の第4週
+
+## Zendesk ビュー
+
+すべての認証および認可関連のチケットを表示するための Zendesk ビューが作成されました。ビューにアクセスするには、[Support Team データ](https://gitlab.com/gitlab-support-readiness/support-team/-/tree/master/data/agents?ref_type=heads) の `zendesk:` セクションの下に `- 'Support Focus: Authentication and Authorization` を追加してください。
+
+例:
+
+```yaml
+ zendesk:
+    main:
+      id: xxxxxxxxxx
+      groups:
+      - 'Support Focus: Authentication and Authorization'
+```

--- a/content/handbook/support/support-pods/ci-cd/_index.md
+++ b/content/handbook/support/support-pods/ci-cd/_index.md
@@ -1,0 +1,88 @@
+---
+title: CI/CD サポート Pod
+description: CI/CD に関するチケット/Issue を議論し、CI/CD の機能を学び、関連ドキュメントを改善します。
+upstream_path: /handbook/support/support-pods/ci-cd/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 目的
+
+CI/CD に関するチケット/Issue を議論し、CI/CD の機能を学び、関連ドキュメントを改善します。
+
+## スコープ
+
+この Pod のトピックは、できる限り次の製品グループと整合させます。
+
+- [Pipeline Authoring](/handbook/product/categories/#pipeline-authoring-group)
+- [Pipeline Execution](/handbook/product/categories/#pipeline-execution-group)
+- [Pipeline Security](/handbook/product/categories/#pipeline-security-group)
+
+「CI/CD」という文脈では、問題がどこに該当するか正確に特定するのが難しい場合があります。このリストは Pod でのヘルプを求めることを思いとどまらせる意図ではありません。迷ったら気軽に聞いてください！最悪でも、誰かがより良い質問先を提案してくれるだけです。
+
+## 現在の目標
+
+- 定例ミーティングを継続する
+- CI/CD のすべてに関して最新情報を把握する
+- CI/CD のチケットでお互いを助け合う！
+
+## サポート Pod のメンバー
+
+- {{< member-by-name "Cleveland Bledsoe Jr" >}} (`@cleveland`)
+- {{< member-by-name "Ryan Kelly" >}} (`@rkelly`)
+- {{< member-by-name "Elif Munn" >}} (`@e_munn`)
+- {{< member-by-name "Edward Hilgendorf IV" >}} (`@edwardhilgendorf`)
+- {{< member-by-name "Duncan Harris" >}} (`@duncan_harris`)
+- {{< member-by-name "Alejandro Guerrero de Alba" >}} (`@alejguer`)
+- {{< member-by-name "Segolene Bouly" >}} (`@sbouly`)
+- {{< member-by-name "Charl Marais" >}} (`@cmarais`)
+- {{< member-by-name "Sarah Crowle" >}} (`@sacrowle`)
+
+## 参加方法
+
+1. マネージャーと話す。
+1. [Support Team データ](https://gitlab.com/gitlab-support-readiness/support-team/-/tree/master/data/agents?ref_type=heads) の自分の knowledge areas に CI を追加する。すでに存在する場合は、レベルをそれに応じて調整する。
+1. チームメイトとグループメイトに新しい注力分野について伝える。
+1. [#spt_pod_cicd](https://gitlab.slack.com/archives/C04DHQ91WJE) Slack チャネルに参加する。
+1. このページに自分を追加する。
+1. CI/CD ペアリングセッションに参加する（カレンダーの扱い方を解明できれば）。`定例ミーティング` を参照し、最新のミーティング時刻については GitLab Support カレンダーを確認してください
+
+## 定例ミーティング
+
+- CI/CD Pod ペアリングセッション:
+  - 月曜 11:00 CET（DST により 09:00 / 10:00 UTC、`GitLab Support` カレンダー参照）
+  - 木曜 15:30 CET（DST により 13:30 / 14:30 UTC、`GitLab Support` カレンダー参照）
+
+## コラボレーションチャネル
+
+- Slack チャネル: [#spt_pod_cicd](https://gitlab.slack.com/archives/C04DHQ91WJE)
+
+## Zendesk で CI/CD ビューをセットアップする
+
+CI/CD 関連のすべてのチケット用に個人ビューを設定することをおすすめします。
+
+1. [Manage Views](https://gitlab.zendesk.com/admin/workspaces/agent-workspace/views) に移動
+2. Add View をクリック
+3. 次のパラメーターでビューを設定する:
+   - **Title**: CI/CD Pod
+   - **Conditions**:
+     - Tickets must meet all of these conditions to appear in the view:
+       - Status is not Closed
+       - Status is not Solved
+       - Status is not pending
+     - Tickets can meet any of these conditions to appear in the view:
+       - Tags contains at least one of the following:
+         - すべての `support_cicd_*` タグを追加
+         - `support_category_cicd` を追加
+   - **Columns**（推奨ですが、お好みで選択できます）:
+     - Next SLA breach
+     - Subject
+     - Requester
+     - Request date
+     - Assignee
+     - Priority
+     - Organization
+   - **Order by**:
+     - Next SLA breach - Ascending

--- a/content/handbook/support/support-pods/code-contributions/_index.md
+++ b/content/handbook/support/support-pods/code-contributions/_index.md
@@ -1,0 +1,70 @@
+---
+title: コードコントリビューションサポート Pod
+description: SE がコードコントリビューションの文脈で協働できる場を提供します。
+upstream_path: /handbook/support/support-pods/code-contributions/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 目的
+
+SE がコードコントリビューションの文脈で協働できる場を提供します。
+
+## 現在の目標
+
+- Pod の認知を高める
+- [#spt_pod_code-contributions](https://gitlab.slack.com/archives/C05DUHAG3EY) Slack チャネルで非同期コミュニケーションを行い、SE をエンパワーし知識を交換する
+
+## サポート Pod のメンバー
+
+- リード: {{< member-by-name "Anton Smith" >}} (`@anton`)
+- {{< member-by-name "Ronald van Zon" >}} (`@rvzon`)
+- {{< member-by-name "Cleveland Bledsoe Jr" >}} (`@cleveland`)
+
+## 参加方法
+
+1. マネージャーと話す。
+1. まだの場合は、[Code Contributions](https://gitlab.com/gitlab-com/support/support-training/-/blob/master/.gitlab/issue_templates/Code%20Contributions.md) サポートトレーニングモジュールに取り組むことを検討する。
+1. [Support Team データ](https://gitlab.com/gitlab-support-readiness/support-team/-/tree/master/data/agents?ref_type=heads) の自分の knowledge areas に Code Contributions を追加する。すでに存在する場合は、レベルをそれに応じて調整 - どのレベルでも Pod では歓迎です！
+1. 任意: 新しい注力分野についてチームに伝える。
+1. [#spt_pod_code-contributions](https://gitlab.slack.com/archives/C05DUHAG3EY) Slack チャネルに参加する。
+1. このページに自分を追加する。
+
+## 定例ミーティング
+
+- 現時点ではありません。同期セッションをセットアップしたい場合は、Slack でメッセージを送るだけです！
+
+## 協働の方法
+
+- Slack チャネル: [#spt_pod_code-contributions](https://gitlab.slack.com/archives/C05DUHAG3EY)
+
+仲間のサポートエンジニアとの協働に加えて、他の GitLab メンバーと協働するための次のような機会も検討してください。
+
+- **Backend Pairs** への参加を検討:
+  - Slack チャネル: [#backend_pairs](https://gitlab.slack.com/archives/CLX2Z53A5)
+  - [Google カレンダー](https://calendar.google.com/calendar/u/0?cid=Y18waWFhcmdxdjUzZGY4cmR1N2g5YmhiNHBpZ0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) を購読。
+  - YouTube の [Backend Pairing playlist](https://www.youtube.com/playlist?list=PL05JrBw4t0KrMuuWVieMsCG2XHWBCJi_2) を視聴。
+  - GitLab の [Backend Engineering](/job-description-library/engineering/backend-engineer/) について読む。
+- **Frontend Pairs** への参加を検討:
+  - Slack チャネル: [#frontend_pairs](https://gitlab.slack.com/archives/CGWPX7516)
+  - [Google カレンダー](https://calendar.google.com/calendar/u/1?cid=Y18waWFhcmdxdjUzZGY4cmR1N2g5YmhiNHBpZ0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) を購読。
+  - GitLab の [Frontend Engineering](/job-description-library/engineering/development/frontend/) について読む。
+
+## コードコントリビューションの機会を見つける
+
+🌊 コードコントリビューションをしたいけれど、どこから始めればよいか分からない？
+
+- Issue を戦略的に検索し、[フィルタ](https://docs.gitlab.com/user/project/issues/managing_issues/#filter-the-list-of-issues)します。
+  - ラベルを試してみて、自分の興味に応じて Issue を探す。簡単な Issue であれば、`Seeking community contributions`、`Accepting UX contributions` で検索し、必要に応じて追加のラベルを足していく
+  - Issue に weight が設定されている場合は、weight `1` の小さい Issue を探す
+  - `@anton`: 私は通常 `api` ラベルが付いた Issue を探すのが好きです。バックエンドのみの変更で済むことが多く、Ruby コードを書くのが好きだからです。可能な限り、サポートに直接役立つ Issue に取り組むのが好みです。
+  - 興味深い練習として、GitLab で働き始めた頃にあなた自身がオープンした Issue を見直し、その後どれだけ成長したかを確認し、コードコントリビューションができないか考えてみるのもよいでしょう。
+- [Support Stable Counterparts](/handbook/support/support-stable-counterparts/) (SSC) の方へ: 担当している製品グループに小さな取り組みがないか聞いてみてください。
+- 監査イベントは取り掛かりやすい題材で、参考にできる例も豊富にあります。[Comprehensive audit log: instance settings](https://gitlab.com/groups/gitlab-org/-/epics/476) Epic を参照してください。
+- [Papercut スプレッドシート](https://docs.google.com/spreadsheets/d/1qFYgeSGbePumjViTbUr7Jn7T6emlDyxshw4YPb6YzEs/edit#gid=0) もチェックしてみてください。
+- 取り組みたい Issue を見つけたら絵文字を付けておくと、後でその絵文字で Issue 一覧を参照できます。
+  - `@anton`: 私は個人的に :ant: を使用しているので、私から付けられた絵文字付き Issue を見かけたら、将来コードコントリビューションする候補として目印を付けたものです :smile:
+- `gitlab-org/gitlab` 以外にもコードコントリビューションの機会はたくさんあることを忘れないでください。`gitlab-org/charts`、`gitlab-org/gitlab-runner`、または [Support Toolbox](https://gitlab.com/gitlab-com/support/toolbox) のプロジェクトへの貢献も検討してください。
+- 取り組みたいことに興味はあるが始め方がよく分からない場合は、Issue をオーナーとする製品チームに気軽に連絡するか、[#backend](https://gitlab.enterprise.slack.com/archives/C8HG8D9MY) や [#frontend](https://gitlab.enterprise.slack.com/archives/C0GQHHPGW) で質問できます。彼らから方針やベストなアプローチについてアドバイスをもらえます。

--- a/content/handbook/support/support-pods/database/_index.md
+++ b/content/handbook/support/support-pods/database/_index.md
@@ -1,0 +1,45 @@
+---
+title: データベースサポート Pod
+description: PostgreSQL、データベースマイグレーション、データベースパフォーマンス、Patroni / レプリケーションなどを扱うサポート Pod です。
+upstream_path: /handbook/support/support-pods/database/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 目的
+
+PostgreSQL、データベースマイグレーション、データベースパフォーマンス、Patroni / レプリケーションなどを扱うサポート Pod です。
+
+## 現在の目標
+
+- チケットでの協働
+- 知識の獲得と共有
+- ドキュメントの改善
+- バグの特定、Issue および MR の作成
+- 関連するサポートトレーニングモジュールの更新支援
+- 大きなサポートチームへのリソース提供
+- 私たちの経験に基づく製品への影響
+- テスト、トラブルシューティング、分析、学習を支援するツールの開発
+- さまざまなデプロイおよびアーキテクチャシナリオの実験
+
+## サポート Pod のメンバー
+
+- リード: {{< member-by-name "Ben Prescott" >}} (`@bprescott_`)
+
+## コラボレーションチャネル
+
+- Slack チャネル: [#spt_pod_database](https://gitlab.slack.com/archives/C05K0R2830A)
+
+## オープンオフィスとペアリングセッション
+
+- Staff / Database Pod オフィスアワー 火曜 08:30 UTC（夏時間） / 09:30 UTC（冬時間）
+- Staff / Database Pod オフィスアワー 水曜 15:00 UTC（夏時間） / 16:00 UTC（冬時間）
+
+## データベースの話題がよく議論される Slack チャネル
+
+- [#database](https://gitlab.slack.com/archives/C3NBYFJ6N)
+- [#g_database](https://gitlab.slack.com/archives/CNZ8E900G)
+- [#g_distribution](https://gitlab.slack.com/archives/C1FCTU4BE)
+- [#support_self-managed](https://gitlab.slack.com/archives/C4Y5DRKLK)

--- a/content/handbook/support/support-pods/docs/_index.md
+++ b/content/handbook/support/support-pods/docs/_index.md
@@ -1,0 +1,39 @@
+---
+title: ドキュメントサポート Pod
+description: ドキュメント関連の MR やその他の Docs 関連項目に共同で取り組むサポート Pod です。
+upstream_path: /handbook/support/support-pods/docs/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 目的
+
+サポートチームのメンバーがドキュメントに関する質問、MR、Issue について一緒に取り組む場です。SE は次のような場合にここから始められます。
+
+- ドキュメントセクションの再構成
+- 改善案の協働
+- 言い回し、書式、内容の議論
+
+## 現在の目標
+
+- ドキュメントへの貢献を簡単に、生産的に、もしかしたら楽しくすること。
+
+## サポート Pod のメンバー
+
+- {{< member-by-name "Keelan Lang" >}} (`@klang`)
+- {{< member-by-name "Michelle Almendarez" >}} (`@Michelle_Almendarez`)
+- {{< member-by-name "Michael Gibson" >}} (`@Mike G`)
+
+## コラボレーションチャネル
+
+[#spt_pod_docs](https://gitlab.enterprise.slack.com/archives/C07UU2R5SKU)
+
+## オープンオフィスとペアリングセッション
+
+Docs Party: 隔週月曜 18:00 UTC。イベントは [GitLab Support カレンダー](/handbook/support/#google-calendar) に掲載されています。
+
+## ドキュメントの話題がよく議論される Slack チャネル
+
+[#docs](https://gitlab.enterprise.slack.com/archives/C16HYA2P5)

--- a/content/handbook/support/support-pods/geo/_index.md
+++ b/content/handbook/support/support-pods/geo/_index.md
@@ -1,0 +1,78 @@
+---
+title: Geo サポート Pod
+description:
+upstream_path: /handbook/support/support-pods/geo/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 目的
+
+Geo のチケットに一緒に取り組む専用のグループを作ります。
+
+これにより、メンバー全員が Geo に関する知識をより深め、リージョンを越えて知識を共有しやすい場所を持つことができます。
+
+## 現在の目標
+
+- Geo に関するチケットでの協働
+
+- 知識の獲得と共有
+
+- ドキュメントの更新
+
+## サポート Pod のメンバー
+
+- リード: {{< member-by-name "Ronald van Zon" >}} (`@rvzon`)
+- 副リード: {{< member-by-name "Anton Smith" >}} (`@anton`)
+- 副リード: {{< member-by-name "Keelan Lang" >}} (`@klang`)
+- {{< member-by-name "Alexander Strachan" >}} (`@astrachan`)
+- {{< member-by-name "Brie Carranza" >}} (`@bcarranza`)
+- {{< member-by-name "Bo Carbonell" >}} (`@bocarbonell`)
+- {{< member-by-name "Daniel Diniz" >}} (`@dnldnz`)
+- {{< member-by-name "Emily Chang" >}} (`@emchang`)
+- {{< member-by-name "Łukasz Korbasiewicz" >}} (`@lkorbasiewicz`)
+- {{< member-by-name "Mario Mora" >}} (`@mmora`)
+- {{< member-by-name "Harish Ramachandran" >}} (`@harishsr`)
+- {{< member-by-name "Aric Buerer" >}} (`@abuerer`)
+
+## コラボレーションチャネル
+
+- Slack チャネル: [#spt_pod_geo](https://app.slack.com/client/T02592416/C03D96JF4LD)
+- Epic - https://gitlab.com/groups/gitlab-com/support/-/epics/145
+
+## 定例ミーティング
+
+- Geo Pod Sync APAC <> AMER - 火曜 21:30 UTC
+- EMEA Geo Group Pairing - 水曜 08:00 UTC
+- Geo Pod Sync EMEA <> AMER - 木曜 14:00 UTC
+
+## Geo Pod ビューの作成
+
+Zendesk の制限により、すべての Pod が共有ビューを持つことはできないため、手動で作成する必要があります。
+以下の手順に従えば、すぐに個人用のビューが作れます。
+
+1. `Manage views` をクリック
+1. 開いた新しいウィンドウの右上で `Add view` をクリック
+1. ビューに分かりやすい名前を付ける（`Geo (All regions)`）
+1. `Conditions` に移動
+    1. `Tickets must meet all of these conditions to appear in the view`
+        1. `Add condition` をクリックし、左から右へ `Status`、`Less than`、`Pending` を設定
+        1. 2つ目の条件として（左から右へ）`Form`、`Is`、`Self-Managed` を追加
+    1. `Tickets can meet any of these conditions to appear in the view`
+        1. `Add condition` をクリックし（左から右へ）`Descripition`、`Contains at least one of the following words`、`geo` を設定
+1. `Formatting options` に進む
+    1. これは好みの部分が大きいですが、以下に推奨例を示します。
+        1. Next SLA breach
+        1. Priority
+        1. Preferred Region for Support
+        1. Subject
+        1. Organization
+        1. Assignee
+        1. Request date
+        1. Latest update by assignee
+1. `Order by` を `Next SLA breach`、`Ascending` に変更
+1. `Save` をクリック
+
+おめでとうございます、これで個人用の Geo Pod ビューが作成できました。

--- a/content/handbook/support/support-pods/get/_index.md
+++ b/content/handbook/support/support-pods/get/_index.md
@@ -1,0 +1,58 @@
+---
+title: GET サポート Pod
+description: GitLab Environment Toolkit (GET) と GitLab Performance Toolkit (GPT) のためのサポート Pod です。
+upstream_path: /handbook/support/support-pods/get/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 目的
+
+GitLab Environment Toolkit (GET) と GitLab Performance Toolkit (GPT) のためのサポート Pod です。
+
+## 現在の目標
+
+- チケットでの協働
+- 知識の獲得と共有
+- ドキュメントの改善
+- バグの特定、Issue および MR の作成
+- 関連するサポートトレーニングモジュールの更新支援
+- 大きなサポートチームへのリソース提供
+- 私たちの経験に基づく製品への影響
+- テスト、トラブルシューティング、分析、学習を支援するツールの開発
+- さまざまなデプロイおよびアーキテクチャシナリオの実験
+
+## サポート Pod のメンバー
+
+- リード: {{< member-by-name "Lewis Brown" >}} (`@lwbrown`)
+- {{< member-by-name "Jessie Lee" >}} (`@jessie`)
+- {{< member-by-name "Mario Mora" >}} (`@mmora`)
+- {{< member-by-name "Keelan Lang" >}} (`@klang`)
+- {{< member-by-name "Wade Jenkins" >}} (`@wwjenkins`)
+- {{< member-by-name "Ryan Castro" >}} (`@rcastro6`)
+
+## コラボレーションチャネル
+
+- Slack チャネル: [#spt_pod_get](https://app.slack.com/client/T02592416/C05NL747NMD)
+- Epic:
+  - https://gitlab.com/groups/gitlab-com/support/-/epics/145
+  - https://gitlab.com/groups/gitlab-com/support/-/epics/191
+
+## オープンオフィスとペアリングセッション
+
+未定
+
+## GET がよく議論される Slack チャネル
+
+- [#gitlab_environment_toolkit](https://app.slack.com/client/T02592416/C01DE8TA545/thread/C015U1TKV4M-1660940872.562939)
+- [#reference-architectures](https://app.slack.com/client/T02592416/C015V8PDUSW/thread/C015U1TKV4M-1660940872.562939)
+- [#g_distribution](https://app.slack.com/client/T02592416/C1FCTU4BE/thread/C015U1TKV4M-1660940872.562939)
+- [#quality](https://app.slack.com/client/T02592416/C3JJET4Q6)
+- [#gitlab_performance_tool](https://app.slack.com/client/T02592416/C02JMABFT2R)
+- [#kubernetes](https://app.slack.com/client/T02592416/C3UCHUA76/thread/C015U1TKV4M-1660940872.562939)
+
+## 学習リソース
+
+https://gitlab.com/gitlab-com/support/support-training/-/blob/master/.gitlab/issue_templates/GitLab%20Environment%20Toolkit.md?ref_type=heads

--- a/content/handbook/support/support-pods/git-and-gitaly/_index.md
+++ b/content/handbook/support/support-pods/git-and-gitaly/_index.md
@@ -1,0 +1,36 @@
+---
+title: Git および Gitaly サポート Pod
+description: Git、Gitaly、Gitaly Cluster、Praefect に関するすべてを扱います。
+upstream_path: /handbook/support/support-pods/git-and-gitaly/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 目的
+
+Git、Gitaly、Gitaly Cluster、Praefect に関するすべてを扱います。
+
+## 現在の目標
+
+- Git および Gitaly に関するチケットでの協働
+- 複雑なシステムに関する知識の共有
+- Gitaly のトラブルシューティングドキュメントの改善
+
+## サポート Pod のメンバー
+
+- リード: {{< member-by-name "Jessie Lee" >}} (`@jessie`)
+- {{< member-by-name "Kaitlyn Chappell" >}} (`@kchappell`)
+- {{< member-by-name "Gerardo Gutierrez" >}} (`@gerardo`)
+- {{< member-by-name "Emily Chang" >}} (`@emchang`)
+- {{< member-by-name "Katrin Leinweber" >}} (`@katrinleinweber`)
+- {{< member-by-name "Chris Kaburu" >}} (`@ckaburu`)
+- {{< member-by-name "Rocky Mongare" >}} (`@rmongare`)
+- {{< member-by-name "Andrew Conrad" >}} (`@a.conrad`)
+- {{< member-by-name "Nathaniel Rosario" >}} (`@nrosario`)
+
+## コラボレーションチャネル
+
+- Slack チャネル: [#spt_pod_git](https://gitlab.slack.com/archives/C04D5FUADAM)
+- Epic - https://gitlab.com/groups/gitlab-com/support/-/epics/145

--- a/content/handbook/support/support-pods/gitlab-dedicated/ssc-monthly-business-review-prep.md
+++ b/content/handbook/support/support-pods/gitlab-dedicated/ssc-monthly-business-review-prep.md
@@ -1,0 +1,112 @@
+---
+title: GitLab Dedicated 月次ビジネスレビュー準備
+description: GitLab Dedicated Support Stable Counterpart がサポート部門の月次ビジネスレビューに向けた準備を行えるようにします。
+upstream_path: /handbook/support/support-pods/gitlab-dedicated/ssc-monthly-business-review-prep/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+毎月、Support Stable Counterpart（SSC）は GitLab サポートの月次ビジネスレビュー（MBR）で利用する情報を準備します。このハンドブックページでは、GitLab Dedicated SSC が任意の MBR 向けに GitLab Dedicated に関するメモを準備するためにどのような手順を踏むべきかをドキュメント化しています。GitLab Dedicated SSC であれば誰でも MBR の調整を主導できます。
+
+## ℹ️ 情報源
+
+各 MBR には次の情報源からの情報を含める必要があります。
+
+- 他の SSC
+- チケット
+- RFH
+- インシデント
+
+各 MBR には他の情報源からの情報も含まれる場合があります。
+
+私たちは GitLab Dedicated（商用）と GitLab Dedicated for Government についてレポートします。GitLab Dedicated for Government に関する具体的なデータを取得するには、Brie または Wade と連携する必要があります。それらの領域は明示的に注記されています。
+
+## メトリクスのまとめ方
+
+再現性を確保するため、MBR 向けにメトリクスをまとめる際は次の手順に従ってください。
+
+### テナント数のカウント
+
+この[スプレッドシート](https://docs.google.com/spreadsheets/d/1tckSKeZkKHrxOfE2otruH8GrHCDxdPYc7ZJIagisqxk/edit?usp=sharing)を参照し、テナントおよび ASE のソースに関してリストが最新であることを確認してください。テナント数をカウントする際には、本番、プリプロダクション、内部テナントの区別に留意してください。Assigned Support Engineer を持つテナントの割合をカウントする際は本番テナントのみを対象とし、その点を MBR スライド内で明示します。
+
+### 📅 集計期間 {#-cutoff-period}
+
+各 MBR では先月の状況を確認します。物事を一度だけカウントするためにも、MBR を準備する際にどの日付を見ているかを特に意識してください。MBR の前週の終わりが[適切な集計区切り](https://gitlab.com/gitlab-com/support/support-team-meta/-/issues/6738#note_2394065104)になります。
+
+このページの末尾の表に、使用した開始日と終了日を記録してください。
+
+### 🎫 チケット数のカウント
+
+#### GitLab Dedicated（商用）
+
+GitLab Dedicated SSC は[Zendesk Explore ダッシュボード](https://gitlab.zendesk.com/explore/studio#/dashboards/07CF8C533919A5124620021181BA5AD59F3463F6A1D60F1FC2C789D5E49079E4)にアクセスできます。チケット数のカウントにはこちらを使用してください。準備対象の MBR に応じた正確なチケット数を集計するためには、**Custom range** オプションを使用してください。
+
+#### GitLab Dedicated for Government
+
+_作業中です。_
+
+### 🆘 RFH 数のカウント
+
+#### GitLab Dedicated（商用）
+
+1. 統合 `request-for-help` [プロジェクト](https://gitlab.com/gitlab-com/request-for-help)内の[Issue](https://gitlab.com/gitlab-com/request-for-help/-/issues/?sort=created_date&state=opened&first_page_size=100) を、`Label` `is one of` `Help group::Dedicated`、`Help group::switchboard`（[直接リンク](https://gitlab.com/gitlab-com/request-for-help/-/issues/?sort=created_date&state=all&or%5Blabel_name%5D%5B%5D=Help%20group%3A%3ASwitchboard&or%5Blabel_name%5D%5B%5D=Help%20group%3A%3ADedicated&first_page_size=20)）でフィルタします。
+
+1. **All** を選択
+1. **Created Date** でソート
+1. **Sort direction** を **Descending** に設定
+
+集計期間内にオープンされた Issue をすべてカウントしてください。
+
+#### GitLab Dedicated for Government
+
+CompSecGov 上の[該当プロジェクト](https://compsecgov.gitlab-dedicated.us/gitlab-dedicated-us-public-sector/incident-management)にある RFH Issue について、上記と同じ手順を実施してください。
+
+執筆時点では、Wade と Brie だけがこの情報を取得できる GitLab Dedicated SSC です。（US Government Support チームの他のメンバーが手伝うことができます。）
+
+### 🚨 ページ数のカウント
+
+私たちは、インシデントの総数ではなくページの総数をカウントします。（すべてのインシデントが GitLab サポートチームに関わるわけではありません。）
+
+#### GitLab Dedicated（商用）
+
+[Incident Management - GDCMOC](https://gitlab.pagerduty.com/service-directory/P8WVAI0) サービスを使用し、集計期間内の **Resolved Incidents** の数を数えてください。
+
+#### GitLab Dedicated for Government
+
+[Incident Management - GitLab Dedicated for US Gov CMOC](https://gitlab.pagerduty.com/service-directory/PQRVHA8) サービスを使用し、集計期間内の **Resolved Incidents** の数を数えてください。
+
+執筆時点では、Wade と Brie だけがこの情報を取得できる GitLab Dedicated SSC です。（US Government Support チームの他のメンバーが手伝うことができます。）
+
+## 取り扱う領域
+
+MBR スライドでは、通常次の項目を取り扱います。
+
+- 主要なメトリクスとトレンド
+- 達成事項
+- Issue・学び・アップデート
+- 助けが必要な領域
+
+また、次の表も含まれます。
+
+| | グローバル | US Government |
+|-|--------|---------------|
+| チケット | | |
+| RFH | | |
+| GDCMOC ページ | | |
+
+各セルには `X（前月比の増加率、先月の X の値）` を記載します。
+
+## 📜 過去の MBR の日付
+
+MBR の準備に使用する **開始日** と **終了日** を記録してください。日付は両端を含めます（`inclusive`）。
+
+| MBR | SSC | 開始日 | 終了日 |
+| ------ | ------ | ------ | ------ |
+| 2025年4月 | Brie Carranza |  N/A      | `2025-04-27` |
+| 2025年5月 | Brie Carranza | `2025-04-28` | `2025-05-16` |
+| 2025年6月 | Armin Hergenhan | `2025-05-17` | `2025-06-20` |
+| 2025年7月 | Armin Hergenhan | `2025-06-21`  | `2025-07-18` |
+| 2025年8月 | Daphne Kua | `2025-07-19`  | `2025-08-24` |
+| 2025年9月 | TBD | `2025-08-24`  |  |

--- a/translation-state/manifest.json
+++ b/translation-state/manifest.json
@@ -17022,6 +17022,48 @@
       "model": "claude-opus-4-7",
       "input_hash": "c0ff411b22b148adfaf7db487fe1217a341c26a56b1e6233ac4e165cca0e0876"
     },
+    "content/handbook/support/support-pods/ai/_index.md": {
+      "path": "content/handbook/support/support-pods/ai/_index.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "1ce9964721bfe9450186ca7e36e0f9d249797dcfa30b1aa64c64347807a77dd7"
+    },
+    "content/handbook/support/support-pods/authentication-and-authorization/_index.md": {
+      "path": "content/handbook/support/support-pods/authentication-and-authorization/_index.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "05400d10d6ac943ceb7b5fd3bf6a8e938a92d9065ef96c8264e5166baa6d4d7c"
+    },
+    "content/handbook/support/support-pods/ci-cd/_index.md": {
+      "path": "content/handbook/support/support-pods/ci-cd/_index.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "a5260c979376e135326a7bb94b72f7f01aed8af15fdf1401c0b251ecdc6d2940"
+    },
+    "content/handbook/support/support-pods/code-contributions/_index.md": {
+      "path": "content/handbook/support/support-pods/code-contributions/_index.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "219593408e6458baccc56739acbac89bf246f01eed9470b36aeb9e31dc759e5e"
+    },
+    "content/handbook/support/support-pods/database/_index.md": {
+      "path": "content/handbook/support/support-pods/database/_index.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "97ebd07da98f45441b9aa3df72190d29066079c85ec86a9e15824a165d16bd2b"
+    },
+    "content/handbook/support/support-pods/docs/_index.md": {
+      "path": "content/handbook/support/support-pods/docs/_index.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "12c15922f1199272ef3597231f5ca8a5044fd06f9fd67f7839ca9e6044677a29"
+    },
     "content/handbook/support/support-pods/example-pod.md": {
       "path": "content/handbook/support/support-pods/example-pod.md",
       "upstream_sha": "c8fa138220d8c6d69f811b17242d6d2f08e4e409",
@@ -17029,12 +17071,40 @@
       "model": "claude-opus-4-7",
       "input_hash": "eb6dcb9c72878faba86c2fa0ca76ee23409b9f83173042da671ccf4518dc3e19"
     },
+    "content/handbook/support/support-pods/geo/_index.md": {
+      "path": "content/handbook/support/support-pods/geo/_index.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "ff9c3895834015751040cd797116e9f4509c881adabed0a45a4eb6ebecdc7d61"
+    },
+    "content/handbook/support/support-pods/get/_index.md": {
+      "path": "content/handbook/support/support-pods/get/_index.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "9c7ac73353b4c5353f8284d33a02ea57180036d3968a4674994876d8db587467"
+    },
+    "content/handbook/support/support-pods/git-and-gitaly/_index.md": {
+      "path": "content/handbook/support/support-pods/git-and-gitaly/_index.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "af6fd6588a62f21c542432883fbeea74251eac95f0289682c2c5de019067f5dc"
+    },
     "content/handbook/support/support-pods/gitlab-dedicated/_index.md": {
       "path": "content/handbook/support/support-pods/gitlab-dedicated/_index.md",
       "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
       "translated_at": "2026-05-08T00:00:00Z",
       "model": "claude-opus-4-7",
       "input_hash": "c56e917663f5e471cc6c47f476804ed68abd56b87db4e56766ef206efe28c569"
+    },
+    "content/handbook/support/support-pods/gitlab-dedicated/ssc-monthly-business-review-prep.md": {
+      "path": "content/handbook/support/support-pods/gitlab-dedicated/ssc-monthly-business-review-prep.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "a3fd4c405ff49953e34cccc31398c080a04a87c4b7326ca5f37d49efe3c7fc32"
     },
     "content/handbook/support/support-pods/import/_index.md": {
       "path": "content/handbook/support/support-pods/import/_index.md",


### PR DESCRIPTION
## Summary
- 10 ファイルを翻訳・追加（support-pods 配下の残りサブセクション + dedicated/ssc-mbr-prep）
- upstream SHA: \`1426909c018f3e75bf94ea36ef7e2a30be77e167\`
- translator サブエージェント (\`.claude/agents/translator.md\`) で生成、\`translation-state/manifest.json\` を更新済み
- このPRは #125 を base にしているので、先行PRが順にマージされたら自動で main に rebase されます

## 翻訳ファイル
- \`content/handbook/support/support-pods/gitlab-dedicated/ssc-monthly-business-review-prep.md\`
- \`content/handbook/support/support-pods/git-and-gitaly/_index.md\`
- \`content/handbook/support/support-pods/get/_index.md\`
- \`content/handbook/support/support-pods/geo/_index.md\`
- \`content/handbook/support/support-pods/docs/_index.md\`
- \`content/handbook/support/support-pods/database/_index.md\`
- \`content/handbook/support/support-pods/code-contributions/_index.md\`
- \`content/handbook/support/support-pods/ci-cd/_index.md\`
- \`content/handbook/support/support-pods/authentication-and-authorization/_index.md\`
- \`content/handbook/support/support-pods/ai/_index.md\`

## 注記
- ショートコード \`{{< member-by-name >}}\` は原文のまま保持
- \`ai/_index.md\` の \`#regular-meetings\` 等のアンカーを見出しに明示付与

## Test plan
- [x] \`hugo --renderToMemory\` クリーン（キャッシュ削除後）、エラー 0 件
- [ ] CodeRabbit レビュー対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション

* **Documentation**
  * サポートチームの各ポッド（AI、認証・認可、CI/CD、コード貢献、データベース、ドキュメント、Geo、GET、Git・Gitaly、GitLab Dedicated）に関するハンドブックページを新たに追加しました。各ページではポッドの目的、現在の目標、メンバー、参加方法、定例ミーティング、コラボレーション用チャネルなどの情報を記載しています。
  * GitLab Dedicated向けの月次ビジネスレビュー準備手順ドキュメントを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->