### PR TITLE
translation: 10 handbook support pages (advanced-search/readiness/partnerships)

### DIFF
--- a/content/handbook/support/partnerships/_index.md
+++ b/content/handbook/support/partnerships/_index.md
@@ -1,0 +1,11 @@
+---
+title: パートナーシップ
+description: "パートナーシップのワークフロー、自動化、プロセスに関するサポート固有の情報。"
+upstream_path: /handbook/support/partnerships/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+GitLab Partner Program では、さまざまな種類のパートナーが利用可能です。各タイプのパートナーの説明については、それぞれのページをご参照ください:

--- a/content/handbook/support/partnerships/alliance-partner-support-guide.md
+++ b/content/handbook/support/partnerships/alliance-partner-support-guide.md
@@ -1,0 +1,76 @@
+---
+title: Alliance パートナー サポートガイド
+description: "Alliance パートナーとの連携方法に関する Support Engineering 向けガイド"
+upstream_path: /handbook/support/partnerships/alliance-partner-support-guide/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## GitLab の連絡先 {#gitlab-contacts}
+
+- **DRI** Tine Sørensen - Manager, Support Engineering, EMEA - @tsorensen
+- **ディレクター** Val Parsons - Director of Support Engineering, EMEA - @vparsons
+- **AMER タイムゾーンの連絡先** Mike Dunninger - Manager, Support Engineering, AMER - @mdunninger
+- **APAC タイムゾーンの連絡先** Wei-Meng Lee - Senior Manager, Support Engineering, APAC - @weimeng-gtlb
+
+## Alliance パートナーとのサポート連携
+
+GitLab の Alliance パートナーは、共通のお客様のために GitLab とサポート連携を行うことがあります。共通のお客様とは、Alliance パートナー製品と GitLab 製品の両方を購入されているお客様です。すべての顧客は Ultimate ライセンスを保有しています。
+
+サポート連携とは、GitLab 関連のチケットについて、Alliance パートナーが 1 次サポートを行い、2 次および 3 次サポートのために GitLab に引き継ぐことを意味します。
+
+ほとんどの事項は他の顧客と同様に進みますが、以下のとおりいくつかの違いがあります。
+
+## 一般的な情報
+
+### Alliance パートナー Slack チャネル
+
+GitLab Support は Alliance パートナーのサポートチームと Slack チャネルを共有しています。これらは #a_[Alliance パートナー名] という名前です。チャネルは主にエスカレーションに使用されますが、必要に応じてサポートチーム間のコラボレーションにも利用できます。
+
+Slack で問題を解決することはなく、解決はチケット内でのみ行います。ただし、Alliance パートナーのサポートチームから追加情報が必要な場合に、Slack チャネルでコンタクトを取ることはあります。たとえば、問題が GitLab と Alliance パートナーの両製品にまたがる場合や、トラブルシューティングに必要な資料を入手する手助けが必要な場合などです。トピックが特定のチケットに関する場合は、Alliance パートナーのチケット ID を必ず含めてください。
+
+### 定期的な接点
+
+Alliance パートナーのサポートチームと定期的にミーティングを行い、コラボレーションが円滑に機能し、お客様が優れたサポートを受けられるよう確認しています。アジェンダにトピックを追加したい場合は [Alliance パートナーの DRI](/handbook/support/partnerships/alliance-partner-support-guide/#gitlab-contacts) にご連絡ください。
+
+### ZenDesk 組織
+
+Alliance パートナーの ZenDesk 組織には誰も追加しないでください。必要な場合は [上記の連絡先](/handbook/support/partnerships/alliance-partner-support-guide/#gitlab-contacts) にご相談ください。
+
+## サポートガイド
+
+### チケットの顧客
+
+チケットはパートナー側のサポートチームによって作成されますが、その元となる顧客は多数の異なる個別のお客様です。チケット内のコンテンツは、Alliance パートナーのチケットシステムにある顧客レポートから、私たちのシステムへ一字一句そのままコピーされます。つまり、返信は顧客から直接届くものになります。
+
+チケット内のお客様は、GitLab と Alliance パートナーの双方の顧客です。
+
+### チケットの命名
+
+チケットは次の形式で命名されます: `[Customer name] - [Alliance partner internal ticket id] - [Ticket Subject]`
+
+### チケットへの顧客追加
+
+Alliance パートナーのサポートチームは、チケット作成時に顧客を CC として追加する必要があります。他の顧客と同様に、GitLab 側ではチケットに連絡先を追加しません。
+
+### サポートプロセスの違い
+
+GitLab のサポートプロセスは、Alliance パートナーのサポートチームの働き方とは異なる場合があり、必ずしも直感的ではない可能性があることに留意してください。常に [ポジティブな意図を仮定](/handbook/values/#assume-positive-intent) しましょう。
+
+また、特定のパートナーには [特別なプロセス](https://internal.gitlab.com/handbook/support/specific-alliance-partners/) (GitLab 内部リンク。チームメンバーのみアクセス可) が存在する点にも注意してください。
+
+### スコープ
+
+Alliance パートナーは、初期のチケットトリアージと 1 次サポートを担当します。GitLab Support は 2 次および 3 次サポートを担当します。
+
+### チケットの優先度
+
+Alliance パートナーがチケットをトリアージし、初期の優先度を設定します。GitLab Support は初回応答時にチケットの優先度が適切に設定されているとみなします。
+
+後の時点で優先度が変わった場合や、優先度の調整が必要だと判断した場合は、チケット内で顧客に確認した上で、[通常のプロセス](/handbook/support/workflows/setting_ticket_priority/#resetting-ticket-priority) に従って優先度を変更します。
+
+### 顧客との通話
+
+顧客との通話には、関連する Alliance パートナーのサポートエンジニアを必ず追加してください。

--- a/content/handbook/support/partnerships/alliance.md
+++ b/content/handbook/support/partnerships/alliance.md
@@ -1,0 +1,45 @@
+---
+title: Alliance パートナー
+description: "Alliance パートナー向けのサポート固有の情報"
+upstream_path: /handbook/support/partnerships/alliance/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## サポートへの問い合わせ
+
+Alliance および Technology パートナーは、[サポートポータル](https://support.gitlab.com) からチケットを送信することで、当社にお問い合わせいただけます。Alliance パートナーの各担当者は、**初めてチケットを送信する前に**、[サポートポータル](https://support.gitlab.com) でアカウントが作成されるよう手配する必要があります。手配にあたっては、Customer Success Manager、Account Executive、または GitLab Sales チームの他のメンバーにお問い合わせください。
+
+アカウントが作成されたら、Alliance パートナーは [この専用フォーム](https://support.gitlab.com/hc/en-us/requests/new?ticket_form_id=360001172559) のみを使ってチケットを送信してください。他のフォームから送信されたチケットは正しくルーティングされず、遅延の原因となる可能性が高いです。
+
+**サポート向けの注**: Alliance パートナーのアカウントの組織メモに細心の注意を払ってください。これらには、最高品質のサポートを提供する方法に関する重要な情報が含まれていることがよくあります。
+
+[GitLab は Alliance パートナーに発行された NFR ソフトウェアの問題に関するサポートは提供しません。](https://about.gitlab.com/partners/technology-partners/integrate/#-additional-resources--program-policies)
+
+## ファイルアップロード
+
+Alliance パートナーが GitLab Support にファイルを送信する必要がある場合、3 つの方法が利用できます:
+
+- 標準のチケットアップロード (最大 20MB)
+- [Support Uploader](https://about.gitlab.com/support/providing-large-files/#support-uploader)
+- s3 バケットへの専用接続
+  - この方法では、Support 側で必要に応じてファイルを一覧表示・ダウンロードするための、すでに利用可能なアプリケーションを使用します。
+
+## エスカレーション
+
+問題のエスカレーションが必要となる稀なケースに対して、GitLab Support は Alliance パートナー向けにパーソナライズされた Slack ワークフローフォームを用意しており、これによってエスカレーションをトリガーできます。
+
+Slack ワークフローフォームでは以下の情報を尋ねます:
+
+- **リクエスト ID またはケース番号は何ですか?**
+  - これは GitLab のチケット ID または Alliance パートナーのケース番号 (例: `123456` または `T123456789`) のいずれかです。これらの値のみを入力してください (番号記号 (#) やその他のテキストは省略してください)
+- **エスカレーションの理由は何ですか?**
+  - これはエスカレーションを要請する理由です。
+- **どのようなアクションを行ってほしいですか?**
+  - これはエスカレーションによって達成したい望ましい最終結果です。
+
+このフォームはチケットを特定し、そのチケット/ケースに対して [STAR](/handbook/customer-success/csm/escalations/) をトリガーします。
+
+**注** このプロセスは、緊急事態の登録が必要な場合にも使用されます。

--- a/content/handbook/support/partnerships/jihu.md
+++ b/content/handbook/support/partnerships/jihu.md
@@ -1,0 +1,24 @@
+---
+title: JiHu パートナーシップ
+description: "JiHu パートナーシップ向けのサポート固有の情報"
+upstream_path: /handbook/support/partnerships/jihu/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## サポートへの問い合わせ
+
+**注**: サポートに問い合わせる前に、[サポートポータル](https://support.gitlab.com) であなた用のアカウントが事前に作成されている必要があります。これを行うには、まず Customer Success Manager、Account Manager、Sales 担当者、または Support 担当者にお問い合わせください!
+
+JiHu パートナーシップのメンバーは、[サポートポータル](https://support.gitlab.com) を通じて当社にお問い合わせください。送信されるチケットが適切にルーティングされるよう、[この専用フォーム](https://support.gitlab.com/hc/en-us/requests/new?ticket_form_id=360001477519) を使用します。
+
+これにより、Zendesk の JiHu フォームでチケットが開かれます。
+
+## ファイルアップロード
+
+JiHu パートナーシップのメンバーが GitLab Support にファイルを送信する必要がある場合、2 つの方法が利用できます:
+
+- 標準のチケットアップロード (最大 20MB)
+- [Support Uploader](https://about.gitlab.com/support/providing-large-files/#support-uploader)

--- a/content/handbook/support/partnerships/open.md
+++ b/content/handbook/support/partnerships/open.md
@@ -1,0 +1,43 @@
+---
+title: Open パートナー
+description: "Open パートナー向けのサポート固有の情報"
+upstream_path: /handbook/support/partnerships/open/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## Open パートナートラックの説明
+
+リセラー、インテグレーター、その他のセールスおよびサービスのパートナーは、Open トラックでパートナープログラムに参加します。Open は、DevOps 領域や ItaaS、その他の隣接領域で DevOps プラクティスの構築への投資にコミットするすべてのパートナーを対象としています。また、Open トラックは、顧客を開拓したいパートナーや、GitLab について学んだり GitLab パートナーコミュニティに参加したりすることを希望するパートナー向けでもあります。GitLab Open パートナーは、トランザクション (取引) を行うパートナーであるとは限らず、製品の割引やリファラルフィーを得ることができます。
+
+## サポートへの問い合わせ
+
+Open パートナーおよびそのエンドカスタマーは、[Submit a Request](https://support.gitlab.com/hc/en-us/requests/new) フォームからチケットを送信することで、当社にお問い合わせいただけます。効率的なチケット処理のため、また初回応答の遅延を防ぐために、2 つのオプションがあります:
+
+- Open パートナーの場合:
+  - Open パートナーが顧客または自身のためにチケットを起票する場合、[Submit a Request](https://support.gitlab.com/hc/en-us/requests/new) ページを使い、問題に応じた適切なフォームを選択できます。
+- パートナーのエンドカスタマーの場合:
+  - エンドカスタマーが GitLab Support に直接チケットを起票したい場合も、[Submit a Request](https://support.gitlab.com/hc/en-us/requests/new) ページを使い、問題に応じた適切なフォームを選択できます。
+
+新規チケット送信の唯一の要件は、まず [GitLab Support Portal](https://about.gitlab.com/support/portal/) に登録していただくことです。
+
+**サポート向けの注**: 顧客を Select パートナーの組織に紐付けたり、その逆を行ったりしないでください!
+
+## ファイルアップロード
+
+Open パートナーがサポートファイルを送信する必要がある場合、2 つのオプションが利用できます:
+
+- 標準のチケットアップロード (最大 20MB)
+- [大きなファイルの提供](https://about.gitlab.com/support/providing-large-files/#other-methods)
+
+## Open パートナーのサポートチケット送信および対応の例
+
+Open パートナーおよびその顧客に提供されるサポートは、チケットが起票される状況によって異なります。例としては次のようなものがあります:
+
+1. Open パートナーが顧客のために商業的な作業を行っており、チケットを起票する場合。自社用に購入したサブスクリプションを使い、自社のアカウントで起票してください。サポートは **パートナーが購入したサブスクリプションに基づいて** 提供されます。
+
+1. Open パートナーが社内のトレーニング、テスト、ナレッジ構築を行う場合。彼らは [NFR ライセンス](/handbook/resellers/#nfr-programpolicy) を使い、自社のアカウントでチケットを起票してください。
+
+これらは網羅的な例ではありません。ご不明な場合は、チケットが起票される状況について質問してください。

--- a/content/handbook/support/partnerships/select.md
+++ b/content/handbook/support/partnerships/select.md
@@ -1,0 +1,44 @@
+---
+title: Select パートナー
+description: "Select パートナー向けのサポート固有の情報"
+upstream_path: /handbook/support/partnerships/select/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+Select パートナーは招待制であり、GitLab に関する専門性により多くの投資を行い、GitLab を中心とするサービスプラクティスを発展させ、GitLab 製品のリカーリングレベニュー (継続的売上) のさらなる拡大が期待されるパートナーに限定されます。
+
+## サポートへの問い合わせ
+
+Select パートナーおよびそのエンドカスタマーは、[Submit a Request](https://support.gitlab.com/hc/en-us/requests/new) フォームからチケットを送信することで、当社にお問い合わせいただけます。効率的なチケット処理のため、また初回応答の遅延を防ぐために、2 つのオプションがあります:
+
+- Select パートナーの場合:
+  - Select パートナーが顧客または自身のためにチケットを起票する場合、[Submit a Request](https://support.gitlab.com/hc/en-us/requests/new) ページを使い、問題に応じた適切なフォームを選択できます。
+
+- パートナーのエンドカスタマーの場合:
+  - エンドカスタマーが GitLab Support に直接チケットを起票したい場合も、[Submit a Request](https://support.gitlab.com/hc/en-us/requests/new) ページを使い、問題に応じた適切なフォームを選択できます。
+
+新規チケット送信の唯一の要件は、まず [GitLab Support Portal](https://about.gitlab.com/support/portal/) に登録していただくことです。
+
+**サポート向けの注**: 顧客を Select パートナーの組織に紐付けたり、その逆を行ったりしないでください!
+
+## ファイルアップロード
+
+Select パートナーがサポートファイルを送信する必要がある場合、現在 2 つの方法が利用できます:
+
+- 標準のチケットアップロード (最大 20MB)
+- [Support Uploader](https://about.gitlab.com/support/providing-large-files/#support-uploader)
+
+## Select パートナーのサポートチケット送信および対応の例
+
+Select パートナーおよびその顧客に提供されるサポートは、チケットが起票される状況によって異なります。例としては次のようなものがあります:
+
+1. Select パートナーが顧客から GitLab に関する懸念事項を受け、その対応のためにチケットを作成する場合。Select パートナーがチケットを管理し、顧客と GitLab Support の橋渡し役を務めます。サポートは **顧客のサブスクリプションに関わらず [Priority Support](https://about.gitlab.com/support/#priority-support) として** 提供されます。
+
+1. Select パートナーが顧客のために商業的な作業を行っており、チケットを起票する場合。自社用に購入したサブスクリプションを使い、自社のアカウントで起票してください。サポートは **パートナーが購入したサブスクリプションに基づいて** 提供されます。
+
+1. Select パートナーが社内のトレーニング、テスト、ナレッジ構築を行う場合。彼らは [NFR ライセンス](/handbook/resellers/#nfr-programpolicy) を使い、自社のアカウントでチケットを起票してください。
+
+これらは網羅的な例ではありません。ご不明な場合は、チケットが起票される状況について質問してください。

--- a/content/handbook/support/public-sector-knowledge/knowledgearticles.md
+++ b/content/handbook/support/public-sector-knowledge/knowledgearticles.md
@@ -1,0 +1,206 @@
+---
+title: 公共部門ナレッジベース
+description: GitLab 公共部門ナレッジベース
+upstream_path: /handbook/support/public-sector-knowledge/knowledgearticles/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+ナレッジベースは、顧客の問題に対するソリューションを集めた検索可能なリポジトリであり、ユーザーがサポートに連絡することなく素早く回答を見つけられるようにすることを目的としています。
+
+**ナレッジベースの記事はこちらからご覧いただけます**
+
+- [米国公共部門サポート ナレッジベース](https://federal-support.gitlab.com/hc/en-us/sections/29015014994068-Knowledge-Base)
+- [グローバルサポート ナレッジベース](https://support.gitlab.com/hc/en-us/sections/15215649512604-Knowledge-Base)
+
+![Knowledge Management](/images/support/assets/usg_kb.jpg)
+
+ **メリット**:
+
+- チケット作成を抑制できます。
+- ユーザーの問題を素早く解決できます。
+- 一貫した標準的な回答を提供できます。
+- 信頼の文化を育みます。
+- サポートがより難しい問題や改善活動に注力できる時間を生み出します。
+
+## 原則
+
+- **習慣にしましょう。** 解決する価値がある問題なら、保存する価値があります。
+  - 顧客やチームメンバー、あるいは自分自身の問題を解決したら、毎回ナレッジ記事の起票から始めましょう。
+
+- **ナレッジ獲得を加速しましょう。** ツールとプロセスは、ナレッジベースへの追加スピードを高めるためにあるべきです。
+  - コンテキストが最も明確で、顧客のフィードバックにアクセスできる瞬間にナレッジを取り込みましょう。
+  - より良い方法を見つけたら、できる限り早くフィードバックを共有しましょう。
+
+- **顧客のコンテキストを取り込みましょう。** 顧客の文脈で、適切なナレッジを優先的に取り込みます。
+  - 他のユーザーが見つけやすいよう、顧客が説明したエラーや問題そのままの形での文書化に注力しましょう。
+  - ソリューションを文書化する際は、明確な手順とコンテキストを含めます。迷ったら、[Josh Darnit に実行できるか?](https://www.youtube.com/watch?v=cDA3_5982h8) と問いかけましょう。
+
+- **常にイテレーションしましょう。** ナレッジベースは顧客のためであると同時に、私たち自身のためのものでもあります。利用や再利用のたびに見直し・更新を行います。
+  - 再利用はレビューです: 常にイテレーションすることで、ナレッジの品質を高めていきます。
+
+## ナレッジ記事と GitLab のドキュメントの違い
+
+ナレッジベースと製品ドキュメントは、どちらも GitLab のデジタルサポート体験における重要な要素ですが、それぞれ異なるニーズに応えるものです。
+[こちらに例と詳細があります](../knowledge-base/docs-vs-kb/)。
+
+### ドキュメント
+
+ドキュメントが答えるのは「これはどう動作するのか?」です。
+
+- 製品の機能、アーキテクチャ、利用方法に関する包括的な情報を提供します。
+- 現在の製品バージョンの概要を提供します。
+- 多くの場合、より技術的で詳細です。
+- 更新頻度は低めです (新機能のリリース時)。
+- 主にエンジニアや上級ユーザー、製品の詳細を必要とする方々向けに作成されています。
+
+### ナレッジ記事
+
+ナレッジ記事が答えるのは「これをどう直せばよいのか?」です。
+
+- 製品の利用中に直面した問題を解決します。
+- よくある問題や質問への解決策を提供します。
+- 通常はタスク指向で、動画やスクリーンショットを含みます。
+- 新たな問題、新たな回避策、新たなトラブルシューティング、フィードバックに基づいて頻繁に更新されます。
+- 主に顧客のセルフサービス用に作成されています。
+
+## ナレッジ記事を作成すべき理由
+
+ナレッジ記事は、製品の利用中にユーザーがタスクを完了させたり、質問に答えを得たり、直面した問題を修正したりするのに役立ちます。
+
+ナレッジは **内部** または **外部** のいずれにもなり得ることをご存じですか? ナレッジ記事は顧客向けのものだけではありません。社内ユーザー向けでもあります。ナレッジベース内には、社内のチームメンバーを支援する、社内限定のナレッジも提供しています。
+
+エンドユーザーへの情報提供を効率化するために、ナレッジには *タイプ* を設けています。タイプには次のものがあります:
+
+- ハウツー (How-To)
+- 障害/修正 (Break/Fix)
+- FAQ (Q&A)
+- トラブルシューティング (Troubleshooting)
+- プロセス (Process)
+
+## ナレッジ記事を作成すべきタイミング
+
+要するに、誰かがその情報から恩恵を受けるなら、記事を作成すべきです。
+
+考慮すべきいくつかの問いは次のとおりです:
+
+- 顧客が情報を素早く見つけるのに役立つか?
+- よくある質問・問題に答えているか?
+- 何かを行うための再現可能な方法を文書化しているか?
+- サポートの介入なしに顧客が必要なものを得るのに、この情報は役立つか?
+- 頻繁な更新が必要になりそうな情報か?
+- サポートチケットの急増を引き起こしうる新たな問題 (解決策の有無を問わず) か?
+
+## ナレッジ記事に含められる/含めるべき要素は?
+
+- 概要 (Overview)
+- 回避策、根本原因、問題 (Workarounds, Root Cause, Issue)
+- 動画 (動画へのリンク)
+- スクリーンショット (個人を特定できる情報のスクリーンショットを追加しないよう注意)
+- 参考資料 (記事が外部公開の場合、社内リンクには注意)
+
+### ZenDesk のナレッジ記事に関するトレーニング
+
+利用可能なトレーニングの一覧は [ナレッジベースのトレーニングリソース](../knowledge-base/knowledge-base-training) にあります。
+
+## 実装
+
+現在、ナレッジベース記事の作成、変更、公開には [Sync Repo](https://gitlab.com/gitlab-com/support/articles) を使用しています。
+
+Sync repo でナレッジ記事を作成する方法を確認したい方は、[LevelUp 動画](https://levelup.edcast.com/insights/creating-an-knowledge-article-in-the-sync-repo-mp) をご覧ください。
+
+**知っておくべきこと**
+
+- 引き続き Zendesk と連携しています。Sync repo はナレッジ記事を Zendesk と「同期」して、顧客に提示します。
+- Zendesk の Create article ボタンは引き続き表示されますが、Sync repo に誘導されます (注記が表示されます)。
+- ナレッジ記事は引き続きサポートポータルのナレッジベースで表示されます。
+- サポートエンジニアは、検索機能を使ってナレッジ記事やドキュメントをサポートチケットに引き続きリンクできます。
+
+**変わらないこと**
+
+- Zendesk は引き続きサポートチケットのツールです
+- 顧客から見た違いはありません
+- 内部記事の可視性も変わりません (内部限定のコンテンツには 🔒 アイコンが付きます)
+- 記事の閲覧方法は変わりません
+
+- **TL;DR**: 読む体験は同じ、書くプロセスが新しくなりました。
+
+## Sync Repo でのナレッジ記事の作成方法
+
+以下のプロセスは、WebIDE とナレッジ記事テンプレートを使ってナレッジ記事を作成する手順です。視覚的なガイドとして [動画](https://drive.google.com/file/d/1oxcPg4IA3yRDAshab31yO8Yf24XqmvY8/view?usp=sharing) も用意されています。
+
+1. Sync Repo プロジェクトの [Articles](https://gitlab.com/gitlab-com/support/articles) にアクセスします
+2. WebIDE を開きます (キーボードのピリオドキーで WebIDE を起動できます)
+3. Knowledge Articles の隣の矢印 (右側) を展開し、Templates フォルダを選択します。
+4. Templates フォルダの隣の矢印を展開し、いずれか (Breakfix, FAQ, How-To, Process) を選択します。
+5. ファイル全体の内容を **コピー** します
+6. Knowledge Articles 配下のいずれかのセクション (Administrative, CI_CD Pipeline, Errors, how To, Kubernetes, Licensing and subscription, Migrations, Other articles, performance, Security, Upgrades, Troubleshooting) に移動します。**注**: 追加が必要なセクションが見当たらない場合も、追加方法があります! セクションの詳細はこちらをご覧ください: https://handbook.gitlab.com/handbook/security/customer-support-operations/zendesk/knowledge-center/sections/#current-sections-in-use
+7. 名前を右クリックして「FILE」を選択します
+8. ファイル名 (記事のタイトル) を入力し、末尾に .md を付けます。例: TitleOfYourKnowledgeArticle.md
+9. コピーしたテンプレートの内容を右側のパネルに貼り付けます。
+10. ナレッジ記事の本文 (詳細) を入力します (必要に応じて情報を追加・削除します)。
+11. 保存し、コミットしてマージリクエスト (MR) を作成します
+
+メタデータの先頭フィールドを **最初に** 更新します:
+
+- **Title**: タイトル (ナレッジ記事のタイトル) に変更します
+- **Previous Title** (Title と一致させます)
+- **Category**- Knowledge Articles (そのままにします)
+- **Section** - 記事を配置するセクション (Administrative, CI/CD Pipeline, Errors, How To, Kubernetes, Licensing and Subscription, Migrations, Other articles, Performance, Security, Upgrades, Troubleshooting) を追加します。
+- **Author** (あなた自身になります)
+- **Tags** - バージョン固有の詳細を追加します。例: '17.10'
+- **Labels** - レポート関連の詳細や製品の詳細です。例: 'Runner', 'Duo'
+- **Instances** - 記事は Global と Gov の両ナレッジベースに表示されます。Gov のみに表示する場合は Global を削除します。Global のみに表示する場合は Gov の行を削除します。
+- **Public** - TRUE に設定されています。これは記事が一般公開されることを示します。記事を内部限定にする場合は FALSE に設定します。
+- **convert_markdown** - 記事が HTML 形式で、それを Markdown に変換した場合は、`convert_markdown` を `true` に変更する必要があります。記事を HTML 形式のままにする場合は、`convert_markdown` は `false` のままにします。
+
+**注**: その後ワークフローが開始されます - MR が作成され、レビュアーがレビューを行い、記事が承認されて Sync Repo に追加され、ナレッジベースに表示されます。
+
+## ナレッジ記事を作成するその他の方法
+
+**オプション 1 - 外部テンプレート リクエスト**
+
+1. [フォルダにアクセスしてテンプレートを選択](https://drive.google.com/drive/folders/1hpHAB51x49bRS1tfUqxiQ56UnlITtFHR) します
+2. テンプレートを使って記事を作成し、ドキュメントを保存します。
+3. ナレッジ用 Slack チャネル [#spt_knowledge-base](https://gitlab.enterprise.slack.com/archives/C07QDCG4AGH) で記事の作成を依頼します。{{< member-by-name "Kirsty Allen" >}} をメンションしてください。
+4. あなたの記事が Sync repo に作成され、レビュアーに割り当てられた後に公開されます。
+5. ロールと権限はそのままです。本日と同じ「レビュアー」が、記事を公開するための MR を承認できます。
+
+**オプション 2. - Support Team Meta のテンプレート**
+
+1. [Support Team Meta](https://gitlab.com/gitlab-com/support/support-team-meta/-/issues) 配下の **テンプレート** を使用します。テンプレート名は `knowledge-base-article-request` です。{{< member-by-name "Kirsty Allen" >}} を必ずメンションしてください
+2. あなたの記事が Sync repo に作成され、レビュアーに割り当てられた後に公開されます。公開時に通知されます。
+
+**オプション 3. - Articles Repo のテンプレート**
+
+1. [Articles](https://gitlab.com/gitlab-com/support/articles/-/work_items) 配下の **テンプレート** を使用します。テンプレート名は `knowledge-base-article-request` です。{{< member-by-name "Kirsty Allen" >}} を必ずメンションしてください
+2. あなたの記事が Sync repo に作成され、レビュアーに割り当てられた後に公開されます。公開時に通知されます。
+
+**オプション 4 - Slack 経由で作成**
+
+ナレッジに新規 Issue を作成するには、Slack で以下のコマンドを使用します
+
+- /gitlab gitlab-com/support/articles issue new
+
+Slack で既存の Issue を更新するには、Slack で以下のコマンドを使用します
+
+- /gitlab gitlab-com/support/articles issue comment  ワークアイテム番号 (Shift + Enter) コメントを追加
+
+### ロールと権限
+
+3 つのロールがあります: サポートエンジニア、ナレッジチャンピオン、ナレッジ管理者です。
+
+- **ナレッジコントリビューター**: チケット内で KB 記事を作成、更新、利用します。
+- **テクニカルレビュアー**: 公開前に記事の技術的正確性をレビューします。
+- **ナレッジチャンピオン (コーチ)**: 作成、修正、レビュー、公開を行うほか、ジュニアメンバー (ナレッジ) のメンタリングや、ナレッジ化の機会の特定を行います。
+- **ナレッジ管理者**: プロセスが守られるよう徹底し、アーカイブ・復元の支援を行います。
+
+詳細については [ナレッジのロール、権限、責務](/handbook/support/knowledge-base/knowledge-roles/) のページをご参照ください。
+
+### ヘルプの入手
+
+ご質問は専用の [#spt_knowledge-base](https://gitlab.enterprise.slack.com/archives/C07QDCG4AGH) Slack チャネルでどうぞ。
+
+権限関連の問題については、ナレッジ専用 Slack チャネル [#spt_knowledge-base](https://gitlab.enterprise.slack.com/archives/C07QDCG4AGH) を使用していただくか、[Issue](https://gitlab.com/gitlab-com/support/support-team-meta) を作成して {{< member-by-name "Kirsty Allen" >}} をメンションしてください。

--- a/content/handbook/support/readiness/_index.md
+++ b/content/handbook/support/readiness/_index.md
@@ -1,0 +1,31 @@
+---
+title: Readiness チーム
+description: Readiness サブ部門について知りたいことのすべて
+canonical_path: "/handbook/support/readiness/"
+upstream_path: /handbook/support/readiness/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 目的
+
+Support Readiness の目的は、以下を通じて GitLab が顧客に素晴らしい体験を提供できるようにすることです:
+
+- カスタマーサポートチームに、生産性を最適化し、顧客の問題を効率的に解決するためのナレッジ、ツール、データを提供する。
+- 顧客や GitLab 全体に、顧客の問題が発生する前に防ぐためのデータ、ナレッジ、洞察を提供する。
+- 社内外の顧客の双方に対して、素晴らしい体験を届ける。
+
+*目的のステートメントは必要に応じて、少なくとも 3 年ごとに見直されます*
+
+## 採用計画
+
+現在、Support Operations では採用計画に比率を用いています。使用している比率は次のとおりです:
+
+- サポートエンジニア 40 名につき、Support Operations スペシャリスト 1 名
+- Support Operations スペシャリスト 10 名につき、Support Operations マネージャー 1 名
+
+## Support Readiness 関連リンク
+
+- [Readiness サブグループ](https://gitlab.com/gitlab-com/support/readiness)

--- a/content/handbook/support/readiness/data/_index.md
+++ b/content/handbook/support/readiness/data/_index.md
@@ -1,0 +1,53 @@
+---
+title: Support Readiness - データ
+description: サポートがデータをどのように扱うかについて知りたいことのすべて
+canonical_path: "/handbook/support/readiness/data"
+upstream_path: /handbook/support/readiness/data/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 目的
+
+## チームを紹介します
+
+サポートのデータニーズに継続的に関わっているメンバーは次のとおりです:
+
+| 名前                                                  | 役割                                  | 専門領域                             |
+|-------------------------------------------------------|---------------------------------------|---------------------------|
+| [Melissa Magoma](https://gitlab.com/Melissa_Magoma)   | Support Readiness スペシャリスト         | サービスデリバリー |
+| [Ilia Kosenko](https://gitlab.com/Ikosenko)           | Support Engineering マネージャー          | データ |
+
+## データ可視化ガイドライン
+
+私たちは [GitLab Pajamas デザインシステム](https://design.gitlab.com/) の[アクセシビリティに関する推奨事項](https://design.gitlab.com/data-visualization/color#accessibility)に従っています。
+
+### 配色の推奨
+
+パフォーマンスインジケーター:
+
+- **SSAT**: #5A5087 (パープル)
+- **FRT**: #D7786E (レッド)
+- **NRT**: #F0AF64 (イエロー)
+
+チケット優先度:
+
+- **Low**: #FFA600 (イエロー)
+- **Normal**: #F57F6C (サーモン)
+- **High**: #D45384 (マゼンタ)
+- **Urgent / Emergency** ##5A5087 (パープル)
+
+リージョン:
+
+- **AMER**: #D7786E (レッド)
+- **APAC**: #5A5087 (パープル)
+- **EMEA**: #F0AF64 (イエロー)
+- **All Regions**: #52b87a (グリーン)
+
+詳細については [GitLab Support Data Visualization Style Guide](https://drive.google.com/drive/u/0/search?q=GitLab%20Support%20Data%20Visualization%20Style%20Guide) (GitLab 内部のみ) をご参照ください。
+
+### カラーパレット
+
+[GitLab Support Data Visualization Style Guide](https://drive.google.com/drive/u/0/search?q=GitLab%20Support%20Data%20Visualization%20Style%20Guide) (GitLab 内部のみ) をご参照ください。

--- a/content/handbook/support/support-pods/advanced-search/_index.md
+++ b/content/handbook/support/support-pods/advanced-search/_index.md
@@ -1,0 +1,26 @@
+---
+title: Advanced Search サポートポッド
+description: 検索関連のチケットでお互いに支援し合える専用グループです。
+upstream_path: /handbook/support/support-pods/advanced-search/
+upstream_sha: 1426909c018f3e75bf94ea36ef7e2a30be77e167
+translated_at: "2026-05-08T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 目的
+
+Advanced Search サポートポッドは、**検索 (Search)** 関連のチケットでお互いに支援し合える専用グループです。
+
+## 現在の目標
+
+- Advanced Search のチケットで協力し、ナレッジを共有する
+- 成熟度を高めつつある Zoekt (Exact code search) を学習し、理解を深める
+
+## サポートポッドメンバー
+
+- リード: {{< member-by-name "Cleveland Bledsoe Jr" >}} (`@cleveland`)
+
+## コラボレーションチャネル
+
+- [#spt_pod_advanced-search](https://gitlab.slack.com/archives/C05M99TRDHV) Slack チャネル

--- a/translation-state/manifest.json
+++ b/translation-state/manifest.json
@@ -16938,6 +16938,48 @@
       "model": "claude-opus-4-7",
       "input_hash": "8e3178895a432b1241a712c2f764c8c0f8ca3f4e8e0d4c4e225638806975cdc5"
     },
+    "content/handbook/support/partnerships/_index.md": {
+      "path": "content/handbook/support/partnerships/_index.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "8874975510839f0c784a0e316601bff082cb90c8bcc1bc15937c54a1e3641ca9"
+    },
+    "content/handbook/support/partnerships/alliance-partner-support-guide.md": {
+      "path": "content/handbook/support/partnerships/alliance-partner-support-guide.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "e055cab5640e367c2432a6328702a2a5282fcacffa3003a5f1f1620e2d7ff6c1"
+    },
+    "content/handbook/support/partnerships/alliance.md": {
+      "path": "content/handbook/support/partnerships/alliance.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "c85f36efad4ab0fc97d7983852fb10da3d511482b7317a82a2f39b55702472bb"
+    },
+    "content/handbook/support/partnerships/jihu.md": {
+      "path": "content/handbook/support/partnerships/jihu.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "de56d0a9b8ac4a4d8e91386255784136964286dca396ed22e1b0d7645c5a6b33"
+    },
+    "content/handbook/support/partnerships/open.md": {
+      "path": "content/handbook/support/partnerships/open.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "2e450951c5f29739f980e0b884ead7a85deb5899c372913d2c3cad39fe6dd5e3"
+    },
+    "content/handbook/support/partnerships/select.md": {
+      "path": "content/handbook/support/partnerships/select.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "15ac68b815889d780582b5d1d60a9c40542cd61c64ef370423dc83eb9a9796bc"
+    },
     "content/handbook/support/performance-indicators.md": {
       "path": "content/handbook/support/performance-indicators.md",
       "upstream_sha": "18c3e90de89449f1cbbf92c21776a3ea7899476c",
@@ -16952,12 +16994,33 @@
       "model": "claude-opus-4-7",
       "input_hash": "0a5385b6f4721d33f602adf505c58827f67e0d7a476db171ee2f03c29cf04061"
     },
+    "content/handbook/support/public-sector-knowledge/knowledgearticles.md": {
+      "path": "content/handbook/support/public-sector-knowledge/knowledgearticles.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "78c52aeffe4d99e9f1dcb4dc0d7195f2b8734b1a5735108f1933131bc92b1e85"
+    },
     "content/handbook/support/providing_excellent_customer_service.md": {
       "path": "content/handbook/support/providing_excellent_customer_service.md",
       "upstream_sha": "18c3e90de89449f1cbbf92c21776a3ea7899476c",
       "translated_at": "2026-05-08T18:00:00Z",
       "model": "claude-opus-4-7",
       "input_hash": "1a49fd08ec26302252cd73cf21db147c58ad62b3b658341c123aac65921826c0"
+    },
+    "content/handbook/support/readiness/_index.md": {
+      "path": "content/handbook/support/readiness/_index.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "9c4babbd536ff726bf00af2254365485bb7a0fac6b87c10a4fa75b67c6cc521a"
+    },
+    "content/handbook/support/readiness/data/_index.md": {
+      "path": "content/handbook/support/readiness/data/_index.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "0430fdc6ceb2abd7704cb83187f8226fe803552dc1e85b616ca0b5cb1ec9a182"
     },
     "content/handbook/support/support-engineer-career-path.md": {
       "path": "content/handbook/support/support-engineer-career-path.md",
@@ -17021,6 +17084,13 @@
       "translated_at": "2026-05-08T00:00:00Z",
       "model": "claude-opus-4-7",
       "input_hash": "c0ff411b22b148adfaf7db487fe1217a341c26a56b1e6233ac4e165cca0e0876"
+    },
+    "content/handbook/support/support-pods/advanced-search/_index.md": {
+      "path": "content/handbook/support/support-pods/advanced-search/_index.md",
+      "upstream_sha": "1426909c018f3e75bf94ea36ef7e2a30be77e167",
+      "translated_at": "2026-05-08T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "1ebe89e49de37728188e29a86a6134996e9c4f4afa6bc0035cbd20d1a0eede37"
     },
     "content/handbook/support/support-pods/ai/_index.md": {
       "path": "content/handbook/support/support-pods/ai/_index.md",


### PR DESCRIPTION
## Summary
- 10 ファイルを翻訳・追加（support-pods/advanced-search + readiness + partnerships + public-sector-knowledge）
- upstream SHA: \`1426909c018f3e75bf94ea36ef7e2a30be77e167\`
- translator サブエージェント (\`.claude/agents/translator.md\`) で生成、\`translation-state/manifest.json\` を更新済み
- このPRは #126 を base にしているので、先行PRが順にマージされたら自動で main に rebase されます

## 翻訳ファイル
- \`content/handbook/support/support-pods/advanced-search/_index.md\`
- \`content/handbook/support/readiness/_index.md\`
- \`content/handbook/support/readiness/data/_index.md\`
- \`content/handbook/support/public-sector-knowledge/knowledgearticles.md\`
- \`content/handbook/support/partnerships/_index.md\`
- \`content/handbook/support/partnerships/alliance-partner-support-guide.md\`
- \`content/handbook/support/partnerships/alliance.md\`
- \`content/handbook/support/partnerships/jihu.md\`
- \`content/handbook/support/partnerships/open.md\`
- \`content/handbook/support/partnerships/select.md\`

## 注記
- \`alliance-partner-support-guide.md\` の \`#gitlab-contacts\` アンカーを見出しに明示付与
- ショートコード \`{{< member-by-name >}}\` は原文のまま保持

## Test plan
- [x] \`hugo --renderToMemory\` クリーン（キャッシュ削除後）、エラー 0 件
- [ ] CodeRabbit レビュー対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * パートナープログラム向けサポートハンドブックを追加しました（Alliance、JiHu、Open、Select各パートナー向けガイドを含む）。
  * Support Readiness チームおよびデータ可視化ガイドのドキュメントを追加しました。
  * 公共部門向けナレッジベース運用ガイドを追加しました。
  * Advanced Search サポートポッドのハンドブックページを追加しました。
  * 翻訳状態マニフェストを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->