### PR TITLE
translation: 10 handbook PSIRT runbooks pages

### DIFF
--- a/content/handbook/security/product-security/psirt/runbooks/cvss-calculation.md
+++ b/content/handbook/security/product-security/psirt/runbooks/cvss-calculation.md
@@ -1,0 +1,10 @@
+---
+title: "CVSS の算出"
+upstream_path: /handbook/security/product-security/psirt/runbooks/cvss-calculation/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+GitLab のセキュリティ Issue における CVSS スコアを判定する際の唯一の正典として、[GitLab CVSS 計算ツール](https://gitlab-com.gitlab.io/gl-security/product-security/appsec/cvss-calculator/)を参照してください。

--- a/content/handbook/security/product-security/psirt/runbooks/hackerone-process.md
+++ b/content/handbook/security/product-security/psirt/runbooks/hackerone-process.md
@@ -1,0 +1,576 @@
+---
+title: "HackerOne プロセス"
+upstream_path: /handbook/security/product-security/psirt/runbooks/hackerone-process/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## GitLab のバグバウンティプログラムの目的と概要
+
+### プロセスの全体像
+
+GitLab の HackerOne プロセスは、構造化されたワークフローを通じて脆弱性報告を管理します。セキュリティ研究者は HackerOne を通じて発見内容を提出し、それを HackerOne チームがトリアージしたうえで GitLab セキュリティチームに引き渡します。ローテーション中の PSIRT エンジニアが有効な報告をアサイン・検証して GitLab Issue にインポートし、CVSS スコアを算出して重大度とバウンティ額を判定します。脆弱性の種類 (公開されたシークレット、脆弱性チェイニング、DNS テイクオーバー) ごとに特定のプロトコルに従い、報告者と定期的なコミュニケーションを維持し、適切な修復追跡を確保します。修正がデプロイされた後、報告はクローズされ、30 日間の待機期間を経て公開される場合があります。優れた報告者はバウンティと Ultimate ライセンスの両方を獲得できる可能性があります。
+
+## 主要なステークホルダーと責任
+
+- HackerOne トリアージチーム
+- GitLab PSIRT セキュリティエンジニアリング
+- PSIRT セキュリティプログラムマネージャー
+- 発見された問題の影響を受ける機能の GitLab Product Manager
+- 発見された問題の影響を受ける機能の GitLab Engineering (Development) Manager
+- SIRT (Security Operations)
+- インフラストラクチャチーム
+
+## HackerOne ワークフロー
+
+- GitLab はバグバウンティプログラムに HackerOne を使用しており、セキュリティ研究者が脆弱性を報告します。
+  - 報告ステータスの変更通知は #hackerone-feed Slack チャンネルに送信されます。
+- プロセス内の主要なキュー:
+  - New: New 状態のすべての報告を含む
+  - GitLab Team: 検証済みでチームメンバーへのアサイン待ちの報告
+  - H1 Triage: HackerOne トリアージチームがレビュー中の報告
+  - Pending Disclosure: レビューと公開準備が整った報告
+- 報告の取り扱いに関する基本原則:
+  - H1 Triage キューでクリティカルまたは High の報告を監視
+  - Medium/Low の報告は自動化で処理
+  - ローテーション中の PSIRT エンジニアは適切なアサインとトリアージを確保すべき
+  - 必要に応じて報告は次のローテーション担当者に再アサイン可能
+- キュー業務プロセス:
+  - 再現テストには Ultimate ライセンス付きの専用 namespace を使用
+  - HackerOne トリアージチームの検証は信頼するが必ず検証する
+  - 作業を始める際は報告を自分にアサイン
+  - 重大度で優先順位付け、重複をクローズ、最古の報告から順にトリアージ
+- 報告検証ワークフロー:
+  - HackerOne によって行われた検証をレビュー
+  - 報告者とコミュニケーションを取り、必要に応じて調査
+  - 報告がスコープ外、機能、Informative、または重複であるかを判定
+- 有効でスコープ内の報告について:
+  - CVSS スコアを算出し適切な重大度を設定
+  - 報告を GitLab Issue にインポート
+  - 適切なラベル、期限を割り当て、関係するチームメンバーに通知
+  - HackerOne で報告状態を「Triaged」に変更
+- 特別な処理プロセスが存在する対象:
+  - 脆弱性チェイニング (1 つの報告に複数の脆弱性)
+  - 公開されたシークレット (トークン、認証情報)
+  - 公開された個人情報
+  - feature flag の背後にある機能
+  - DNS レコードのテイクオーバー
+- アワードとバウンティプロセス:
+  - トリアージ時に部分的なアワードが付与される場合あり
+  - アワード承認は重大度レベルに基づく
+  - 30 日後、修正が確認される前に承認されたアワードが支払われる場合あり
+- Issue の管理と公開:
+  - 報告者と定期的に (少なくとも月次で) コミュニケーション
+  - 必要に応じて SLA 例外プロセスに従う
+  - パッチがリリースされた後 (30 日間の待機期間後) に Issue をクローズして公開
+- 追加の特典:
+  - 3 件以上の有効な報告を行った研究者は 1 年間の Ultimate ライセンスを取得可能
+  - HackerOne トリアージチームのメンバーは Ultimate ライセンスを取得
+
+## HackerOne 報告ライフサイクルのタイムライン
+
+ TBD
+
+## ステップバイステップのトリアージと修復手順
+
+### キュー
+
+- `New` は New 状態のすべての報告を含みます
+- `GitLab Team` は HackerOne トリアージチームによって検証されたものの、まだ特定の GitLab チームメンバーにアサインされていない報告を含みます
+- `H1 Triage` は HackerOne トリアージチームによってトリアージ中の報告です
+- `Pending Disclosure` はレビューおよび公開すべき報告です
+
+### 基本原則
+
+- `GitLab Team` キューが空の場合は、`H1 Triage` キューに `Critical` または `High` と評価された報告がないかを定期的にチェックします。そのように評価された報告がある場合、それらが本当に `Critical` または `High` であるかを評価し、もしそうであれば `H1 Triage` を待たずに直接処理します。
+  - 一般的に、`H1 Triage` と `New` キューに常に目を配り、`Critical` と `High` を探すのが良い習慣です。
+  - `New` キュー内の `Critical` 報告が PSIRT エンジニアによって低い重大度であると評価された場合、なぜこの報告が `Critical` に見えないかを詳述する `Team only` コメントを報告に入力します。これにより、他のチームメンバーに既に簡単にレビューされていることが伝わり、作業の重複を回避できます。報告は `New` キューに残し、HackerOne トリアージチームに引き続きトリアージするよう知らせるメモを残してください。
+- ローテーション中の PSIRT エンジニアは、トリアージ週内に `GitLab Team` にアサインされた_すべての_報告が、(自分自身に) アサインされ、適切にトリアージされるよう、あらゆる努力をすべきです。
+  - 報告がローテーション担当者に再アサインされなかった場合、次のローテーション担当者は自由にそれをアサインできます。
+
+### GitLab チームのオンボーディング
+
+- GitLab セキュリティチームの新メンバーには、適切な[ロールベースのエンタイトルメントテンプレート](https://internal.gitlab.com/handbook/it/end-user-services/access-request/baseline-entitlements/)を使用したアクセスリクエスト Issue で GitLab HackerOne チームへのアクセスが付与されます。これはオンボーディング中にマネージャーによって提出されるべきです。
+- オンボーディング中、新しい GitLab セキュリティチームメンバーは、ロール上必要であれば HackerOne プログラムへの参加を招待されます。
+
+### キューの作業
+
+#### トリアージ用 Ultimate ライセンス付き namespace
+
+脆弱性のテストに必要なプロジェクトとグループを作成するため、必ず[こちらの namespace](https://gitlab.com/gitlab-com/gl-security/product-security/appsec/bug-reproduction) を使用してください。この namespace は HackerOne Issue の再現専用です。
+
+#### HackerOne トリアージチーム
+
+GitLab のバグバウンティプログラムは HackerOne によって管理されています。HackerOne トリアージチームはファーストレスポンダーであり、研究者と協力して報告を検証してから `GitLab Team` にアサインします。
+
+私たちは通常 HackerOne トリアージチームを信頼し、必ずしも報告を再度検証するわけではありません。ただし、ローテーション中の GitLab チームメンバーが再検証したいケースもあります。例 (網羅的ではありません):
+
+- さらなる調査が必要な追加の影響がある場合
+- さらなる調査なしには重大度を適切に評価できない場合
+
+#### GitLab Team
+
+- 報告の作業を開始する際、セキュリティチームメンバーは即座に
+報告を自分にアサインすべきです。
+- Medium/Low の報告はトリアージが自動化されています。PSIRT エンジニアは特別な処理について [Medium/Low 重大度の問題に関する PSIRT セキュリティエンジニア手順](#psirt-security-engineer-procedures-for-mediumlow-severity-issues)を参照してください。
+- すぐには取り掛からない報告を取得することは問題ありません。特に
+重複であったり、自分が詳しい別の報告に関連している場合などです。ただし、推定トリアージ時間を満たせない場合は必ず再アサインしてもらってください。
+- トリアージ作業サイクルを開始する際、チームメンバーは以下のように優先順位を付けるべきです:
+  1. キューを問わず、新規の severity::1/priority::1 Issue を最初に[特定・トリアージ・エスカレーション](/handbook/security/product-security/psirt/runbooks/handling-s1p1/)します。
+  1. 重複と無効な報告をクローズします。
+  1. "Oldest" でソートしてさらにトリアージします。
+  1. `GitLab Team` キューをトリアージします。
+
+  報告者から応答順序について質問された場合は、`06 - Duplicates/Invalid Reports Triaged First` の common response を使用できます。
+- HackerOne トリアージチームによって実行された検証をレビューします
+- 報告者とコミュニケーションを取り、必要に応じて以下のガイドラインに従って調査します:
+  - 報告者またはトリアージチームのいずれかから[明確化を依頼します](#if-a-report-is-unclear)
+  - 自分で報告を検証します
+- 報告に再現用の外部ホストの静的コンテンツが含まれている場合 (例えば CSRF をトリガーする HTML ファイルや `postMessage` Issue を悪用する脆弱性など)、内部で再ホストするために[このプロジェクト](https://gitlab.com/gitlab-com/gl-security/product-security/appsec/vuln-repro-static-pages)の手順に従います
+  - HackerOne 報告者の PoC は使用しないでください。悪意のあるペイロードのリスクを排除しつつ脆弱性をテストする攻撃ペイロードを開発してください。
+- 潜在的な、バウンティ以外の結果:
+  - 報告がスコープ外。アクション可能であれば、Issue は引き続き作成される場合があります。
+  - 報告が上述のように `~"type::feature"` であり、confidential 化や修復スケジューリングは不要。Issue を作成するか、希望すれば報告者に作成を依頼することができますが、報告は「Informative」としてクローズできます。
+  - 報告がそうでなければ [Informative、Not Applicable、または Spam](#closing-reports-as-informative-not-applicable-or-spam) となります。
+    例えば、markdown 自体の機能を超えない[markdown 内のインライン HTML](https://docs.gitlab.com/ee/user/markdown.html#inline-html) に関する報告を多数受けています。
+  - 報告が重複。Issue が以前に HackerOne で報告されていなかったか、または GitLab に既に Issue が存在しないかを確認します。重複の場合:
+    - 報告の状態を「Duplicate」に変更します。
+    - Issue が以前に H1 で報告されていた場合、報告者の評判に影響する可能性があるため、報告 ID を含めます
+    - `01 - Duplicate` の common response を埋めます。GitLab Issue へのリンクを含めます。
+    - 報告者が元の H1 報告にコントリビューターとして追加されることを依頼してきた場合、チームメンバーは裁量で判断できます。
+        ただし、対応する GitLab Issue はパッチリリース後 30 日で公開されるため、デフォルトでは追加しません。重複報告者を追加することを決定した場合、アクセスを許可する前に報告に報告者の機微情報が含まれていないことを確認してください。
+        コントリビューターとして追加する依頼を断る場合は、`05 - Duplicate Follow Up, No Adding Contributors/Future Public Release` common response を使用できます。
+    - 新しい報告によって以前の報告を誤って処理していたことに気付いた場合 (例: informative としてクローズしたが実は有効なバグだった)、元の報告を再オープンし、レーダーから外れていた問題を再び持ち込んでくれた報告者への感謝として新しい報告にバウンティを授与します
+      - 感謝として授与するバウンティは、低重大度の報告については $100、より高重大度については私たちがトリアージ時に支払う初期バウンティと同等にすべきです
+      - プロセスの後半で間違いに気付き、すでに新しい報告にバウンティを授与している場合、バウンティは上記の金額に引き上げるか、すでに高い場合はそのままにします
+      - 重複報告の作成者は、CVE クレジットとブログ記事でも感謝されるべきです
+      - 新しい報告がより高い影響を示している場合、CVSS スコアを算出し、新しい重大度と元の報告に授与した金額の差を新しい報告者に授与します
+- 報告が情報開示に関するものである場合は、[公開されたシークレットのトリアージ](#triaging-exposed-secrets)プロセスに従います。
+- 報告が有効でスコープ内・オリジナルであり、対応・セキュリティ関連のドキュメント変更が必要、または責任ある engineering チームによるさらなる調査が必要な場合:
+  - [CVSS スコアを算出](https://gitlab-com.gitlab.io/gl-security/product-security/appsec/cvss-calculator/)し、得られたベクター文字列 (例: `AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:L`) を報告内の internal comment として投稿します。これは後で CVE ID をリクエストする際に使用されます
+  - 算出した CVSS を使用して、H1 で適切な重大度を検証および/または設定します
+    - 必要に応じて研究者に CVSS を説明し、CVSS スコアはピアによって検証されること、重大度と支払いに関する非効率な誤解を避けるため Awards プロセスへリンクすることを伝えます
+  - H1 で適切な Weakness を検証および/または設定します
+  - 報告が[権限関連](https://docs.gitlab.com/ee/development/secure_coding_guidelines.html#permissions)である場合、適切に API、GraphQL、Elasticsearch で類似 Issue がないかを確認します。Deploy Token、Deploy Key、Trigger Token などの代替認証メカニズムでも確認してください。
+  - H1 で初期[推奨バウンティ](https://docs.hackerone.com/en/articles/8524543-bounties#h_13d3d2c2b7)を追加します
+  - Slack で `/h1 import <report> [project] [options]` を使用して報告を GitLab Issue にインポートします
+    - 注: デフォルトでは、プレースホルダー [CVE Issue](https://gitlab.com/gitlab-org/cves/-/issues) が作成され、最新の [bug bounty council issue](https://gitlab.com/gitlab-com/gl-security/security-department-meta/issues?scope=all&utf8=%E2%9C%93&state=opened&label_name[]=Bug%20Bounty%20Council) に簡単なメモが追加されます。それぞれの作成を防ぐには、`/h1 import` コマンドに `~no-cve` または `~no-bounty` を渡します。
+  - インポートされた GitLab Issue で:
+    - `h1import` によって割り当てられた重大度/優先度を検証します ([重大度と優先度](/handbook/security/engaging-with-security#severity-and-priority-labels-on-security-issues) と [修復 SLA](/handbook/security/product-security/vulnerability-management/sla/#vulnerability-management-slas-and-labels))
+    - 適切な[期限](/handbook/security/engaging-with-security/#due-date-on-security-issues)を割り当てます
+    - 例えば HackerOne triager によって書かれた最終的な再現手順を Issue にコピーするなどして、適切な[`再現方法`](/handbook/security/engaging-with-security/#reproducibility-on-security-issues)セクションを設けます。
+    - 報告がセキュリティ関連のドキュメント変更である場合、`~documentation` ラベルを追加します
+    - [製品カテゴリページ](/handbook/product/categories/)に基づいて Product Manager と Engineering Manager に @ メンションします。トリアージを完了するために engineering からのフィードバックが必要な場合は依頼します
+    - [DevOps ステージ](/handbook/product/categories/#devops-stages)とソースグループに対応するラベルを追加します (`/label ~` コマンド) (階層を形成するカテゴリの概要については[Hierarchy](/handbook/product/categories/#hierarchy) を参照)
+    - 該当する場合は、選択したセキュリティレベルに応じて、Issue、チャット、メールを通じて他の関連チームメンバーに通知します。
+  - HackerOne で報告の状態を「Triaged」に変更します:
+    - トリアージ時に授与されるバウンティ報酬の部分については、[GitLab の H1 ポリシー](https://hackerone.com/gitlab) の `Rewards` を参照してください
+    - 以下の common responses から選択します:
+      - 重大度や有効性が不確実で engineering チームと議論中の報告の場合は `00 - Triaged pending further investigation`
+      - トリアージ時に初期バウンティがない低重大度の報告の場合は `00 - Triaged`
+      - トリアージ時に初期バウンティがある medium、high、critical の報告の場合は `00 - Triaged with Bounty`
+    - コメントに confidential Issue へのリンクを含めます
+  - 関連詳細が頭に新しいうちに CVE Issue と Bug Bounty Council のメモを更新します
+    - CVSS スコアが GitLab.com で self-managed より高い場合、両方のスコアを算出し Bug Bounty Council Issue で共有します。Council がセキュリティ影響が GitLab.com で self-managed より高いことに同意した場合、バウンティ授与は GitLab.com の CVSS に基づきます。CVE とセキュリティリリースのブログ記事は常に self-managed の CVSS を使用します。
+    - bug bounty council のメモで「Public description」フィールドの使用を検討します。関連性があり詳細を明らかにしすぎていない場合、自動的に作成された Duo 生成の Public description を使用できます。このフィールドは [CVE description update automation](https://gitlab.com/gitlab-com/gl-security/product-security/appsec/tooling/security-release-tools/-/blob/master/scripts/cve_description_update.rb) によって取得され、存在する場合は CVE description として使用されます。
+    - 「Suggested Bounty」行には_バウンティ額のみ_を入力します — このバウンティ授与額に関するすべての追加詳細は「Notes」に記載すべきです
+  - HackerOne トリアージチームによる Issue の検証に依拠した場合、自分で検証する時間をカレンダーに設定することを検討してください。これは後で修正を検証する際に役立ちます。
+  - GitLab インフラに対する完全な影響を評価する必要がある場合、<https://gitlab.com> でテストする代わりに、<https://staging.gitlab.com/help> を使用して GitLab メールアカウントでサインインしてください
+    - 複数のユーザーが必要な場合、ステージング環境にアクセスするために 1password Team Vault に保存されている `gitlab-qa-user*` ユーザーの認証情報を使用します
+  - 報告が認証なしで検出可能なバグ (GitLab またはホストしている他のもの) である場合、Red Team または Vulnerability Management に連絡し、スキャンに含められる Nuclei テンプレートの作成に協力してもらうことを検討します
+- 必ず `Pending Disclosure` タブをレビューし、[公開プロセス](#closing-out--disclosing-issues)に従ってください
+
+##### 脆弱性チェイニングの CVSS 算出
+
+通常、各 HackerOne 報告は単一の脆弱性を開示します。しかし、時には単一の報告で 2 つ以上の新たに発見された脆弱性をチェイニングして影響を増大させる場合があります。
+
+単一の報告が 2 つ以上の新しい脆弱性をチェイニングしてより大きな影響を開示する場合、各個別の脆弱性の CVSS を算出_し_、組み合わせた影響に対する追加の「脆弱性チェイニング」CVSS スコアも算出します。対応する bug bounty council Issue で個別の CVSS スコアと「脆弱性チェイニング」CVSS スコアの両方を共有します。
+
+各個別脆弱性の CVSS は、各脆弱性に対して発行される CVE に使用されます。「脆弱性チェイニング」CVSS は、その報告に対するバウンティ授与の判定に使用されます。
+
+以前に開示された脆弱性との「脆弱性チェイニング」を伴う将来の報告については、新たに開示された脆弱性の CVSS のみを算出します。そのような場合、チェイン内の新しい脆弱性のみが「脆弱性チェイニング」CVSS ベースのバウンティの対象となります。
+
+### 公開されたシークレットのトリアージ {#triaging-exposed-secrets}
+
+<details>
+<summary>公開されたシークレットのトリアージに役立つコピー&ペースト可能な Appsec トリアージチェックリストの markdown を表示するにはクリック</summary>
+
+```markdown
+### Appsec Triage checklist
+- [ ] Mitigate the incident if possible
+  - [ ] If the exposed secret is a Agent Token:
+    - [ ] Validate if the token is a valid one by following the steps [here](https://gitlab.com/gitlab-com/gl-security/security-research/verify-kas-token#testing-kas-token-for-validity) and gather the output for the SIRT incident.
+    - [ ] [Reset the token](https://docs.gitlab.com/ee/user/clusters/agent/work_with_agent.html#reset-the-agent-token) and reach out to the owner of the token through Slack DM.
+  - [ ] If the exposed secret is a Personal Access Token:
+    - [ ] Using the API, gather the output of [`/api/v4/user`](https://docs.gitlab.com/ee/api/users.html#for-normal-users-1) and [`/api/v4/personal_access_tokens/self`](https://docs.gitlab.com/ee/api/personal_access_tokens.html#using-a-request-header) for the SIRT incident.
+    - [ ] [Revoke the token](https://docs.gitlab.com/ee/api/personal_access_tokens.html#using-a-request-header-1) and reach out to the owner of the token through Slack DM.
+
+
+
+  - [ ] Post a comment in `#security-revocation-self-service` using [this message template](https://internal.gitlab.com/handbook/security/security_operations/sirt/runbooks/exposed_secrets/#general-revocation-template-for-secrets)
+  - [ ] If the information was leaked in an issue, make the Issue confidential and leave an internal note explaining why it's been made confidential.
+- [ ] Use the `/security` slack command to [initiate](/handbook/security/security-operations/sirt/engaging-security-on-call/#engage-the-security-engineer-on-call) an incident. This will open a Tines case.
+  - [ ] In the description section, include a link to the HackerOne report and any other useful information
+    - [ ] Share the reporter's IP address(es) and time(s) the reporter accessed the sensitive data to assist with incident response.
+  - [ ] In the remediation section, document what time and from what IP used to revoke the token or validate the leak.
+  - [ ] If in doubt, choose "Urgent".
+  - [ ] If you've been able to mitigate the incident, choosing "Not Urgent" is fine. The SEOC typically responds quickly anyway.
+- [ ] Add information to the SIRT Tines case/incident.
+  - [ ] Login to Tines and locate the case that was opened as a result of you triggering an incident using `/security`.
+  - [ ] (If not already shared) Add a note on the Tines case to include the date the secret was leaked, when HackerOne report came in, and when you took any actions.
+  - [ ] Add any comments to the SIRT Tines Case with context or information that might be helpful.
+- [ ] Leave an internal note with a link to the associated Tines case to connect the report to the Tines case for future reference.
+- [ ] Identify the most appropriate [non-CVSS bounty amount](https://gitlab-com.gitlab.io/gl-security/product-security/appsec/cvss-calculator/) and add your initial [suggested bounty](https://docs.hackerone.com/en/articles/8524543-bounties#h_13d3d2c2b7) in H1
+- [ ] Use `/h1 bounty REPORT_ID` to create a comment on the Bug Bounty Council issue (this step should not be necessary if `/h1 import` was previously run without the `~no-bounty` option.)
+- [ ] Support SIRT as required and, if applicable, follow the process for [handling severity::1/priority::1 issues](handling-s1p1.html)
+- [ ] Investigate the location of the exposure, and locations like it, for further exposure.
+  - [ ] Check the history on issue / MR descriptions
+  - [ ] Check git commit history
+  - [ ] Check build artifacts
+  - [ ] Use Advanced Search to look for similar patterns in other projects used by GitLab team members
+- [ ] If it was leaked through GitLab Unfiltered, add the report to the [tracking issue](https://gitlab.com/gitlab-com/gl-security/security-research/video-scanner/youtube-video-scanner/-/issues/17)
+```
+
+</details>
+
+情報やシークレットの公開は、パッチを当てるものがなく、したがって GitLab プロジェクト Issue、CVSS、または CVE が必要ないため、脆弱性とは少し異なる扱いを受けます。漏洩が発生した場合:
+
+- 可能であればインシデントを緩和します
+  - 公開されたシークレットが Agent Token の場合:
+    - [こちらの手順](https://gitlab.com/gitlab-com/gl-security/security-research/verify-kas-token#testing-kas-token-for-validity)に従ってトークンが有効なものであるかを検証し、SIRT インシデントの出力を収集します。
+    - [トークンをリセット](https://docs.gitlab.com/ee/user/clusters/agent/work_with_agent.html#reset-the-agent-token)し、Slack DM でトークン所有者に連絡します。
+  - 公開されたシークレットが Personal Access Token の場合:
+    - API を使用して、SIRT インシデント用に [`/api/v4/user`](https://docs.gitlab.com/ee/api/users.html#for-normal-users-1) と [`/api/v4/personal_access_tokens/self`](https://docs.gitlab.com/ee/api/personal_access_tokens.html#using-a-request-header) の出力を収集します。
+
+      ```bash
+      curl -H "Authorization: Bearer LEAKED_TOKEN" https://gitlab.com/api/v4/user
+      curl -H "Authorization: Bearer LEAKED_TOKEN" https://gitlab.com/api/v4/personal_access_tokens/self
+      ```
+
+    - [トークンを失効](https://docs.gitlab.com/ee/api/personal_access_tokens.html#using-a-request-header-1)させ、Slack DM でトークン所有者に連絡します。
+
+        ```bash
+        curl --request DELETE -H "Authorization: Bearer LEAKED_TOKEN" https://gitlab.com/api/v4/personal_access_tokens/self
+        ```
+
+  - [このメッセージテンプレート](https://gitlab.com/gitlab-com/gl-security/security-operations/sirt/runbooks/-/blob/main/misc/exposed_secrets.md#general-revocation-template-for-secrets)を使用して `#security-revocation-self-service` にコメントを投稿します
+  - 情報が Issue で漏洩した場合、Issue を confidential にし、なぜ confidential にしたかを説明する internal note を残します。
+- `/security` Slack コマンドを使用してインシデントを開始します
+  - SEOC の巻き込みについて詳しくは: <https://handbook.gitlab.com/handbook/security/security-operations/sirt/engaging-security-on-call/#engage-the-security-engineer-on-call>
+  - 説明セクションに HackerOne 報告へのリンクとその他の有用な情報を含めます
+    - インシデント対応を支援するため、報告者の IP アドレスと、報告者が機密データにアクセスした時刻を共有します。
+  - 修復セクションに、トークンを失効させた、または漏洩を検証した時刻と IP を文書化します。
+  - 迷ったら「Urgent」を選択します。
+  - インシデントを緩和できた場合、「Not Urgent」を選択しても問題ありません。SEOC は通常、いずれにせよ迅速に応答します。
+- SIRT Tines ケース/インシデントに情報を追加します。
+  - Tines にログインし、`/security` を使用してインシデントを起動した結果として開かれたケースを特定します。
+  - (まだ共有していない場合) シークレットが漏洩した日、HackerOne 報告が届いた日、何らかのアクションを取った日を含むメモを Tines ケースに追加します。
+  - 役立つ可能性のあるコンテキストや情報を SIRT Tines Case にコメントします。
+- 報告と Tines ケースを将来の参照のために結び付けるため、関連する Tines ケースへのリンクを含む internal note を残します。
+- 最も適切な [non-CVSS バウンティ額](https://gitlab-com.gitlab.io/gl-security/product-security/appsec/cvss-calculator/) を特定し、H1 で初期[推奨バウンティ](https://docs.hackerone.com/en/articles/8524543-bounties#h_13d3d2c2b7)を追加します
+- `/h1 bounty REPORT_ID` を使用して Bug Bounty Council Issue にコメントを作成します (`/h1 import` が以前に `~no-bounty` オプションなしで実行されている場合、このステップは不要です。)
+- 必要に応じて SIRT を支援し、該当する場合は [severity::1/priority::1 Issue の取り扱い](/handbook/security/product-security/psirt/runbooks/handling-s1p1/)プロセスに従います
+- 公開された場所、およびそれに似た場所を、さらなる公開のために調査します。
+  - Issue / MR の説明の履歴を確認します
+  - git コミット履歴を確認します
+  - ビルドアーティファクトを確認します
+  - Advanced Search を使用して、GitLab チームメンバーが使用する他のプロジェクトで類似のパターンを探します
+- GitLab Unfiltered を通じて漏洩した場合、報告を[追跡 Issue](https://gitlab.com/gitlab-com/gl-security/security-research/video-scanner/youtube-video-scanner/-/issues/17) に追加します
+
+### 公開された個人情報のトリアージ
+
+公開されたシークレットを処理する方法と同様に、GitLab プロジェクト Issue、CVSS、または CVE が必要ない、公開された個人情報を処理することがあります。
+
+- 可能であればインシデントを緩和します
+  - 情報が Issue で漏洩した場合、Issue を confidential にし、なぜ confidential にしたかを説明する internal note を残します。
+  - :warning: Issue を confidential にしても添付ファイルは confidential にならないことに注意してください。
+- `/security` Slack コマンドを使用してインシデントを開始します
+  - SEOC の巻き込みについて詳しくは: <https://handbook.gitlab.com/handbook/security/security-operations/sirt/engaging-security-on-call/#engage-the-security-engineer-on-call]>
+  - インシデントの性質として「Information Disclosure」を選択します
+  - 説明セクションに HackerOne 報告へのリンクとその他の有用な情報を含めます
+    - 可能であれば、インシデント対応を支援するため、報告者の IP アドレスと、報告者が機密データにアクセスした時刻を共有します。
+  - こうした漏洩には通常「Not Urgent」で十分です。SEOC は通常、いずれにせよ迅速に応答します。
+- SIRT Tines ケース/インシデントに情報を追加します。
+  - Tines にログインし、`/security` を使用してインシデントを起動した結果として開かれたケースを特定します。
+  - (まだ共有していない場合) シークレットが漏洩した日、HackerOne 報告が届いた日、何らかのアクションを取った日を含むメモを Tines ケースに追加します。
+  - 役立つ可能性のあるコンテキストや情報を SIRT Tines Case にコメントします。
+- 報告と Tines ケースを将来の参照のために結び付けるため、関連する Tines ケースへのリンクを含む internal note を残します。
+- 最も適切な [non-CVSS バウンティ額](https://gitlab-com.gitlab.io/gl-security/product-security/appsec/cvss-calculator/) を特定し、H1 で初期[推奨バウンティ](https://docs.hackerone.com/en/articles/8524543-bounties#h_13d3d2c2b7)を追加します
+- `/h1 bounty REPORT_ID` を使用して Bug Bounty Council Issue にコメントを作成します
+  - ここでは `bounty` のみを使用してインポートしている点に注意してください。
+- 必要に応じて SIRT を支援し、該当する場合は severity::1/priority::1 Issue の取り扱いプロセスに従います
+- 公開された場所、およびそれに似た場所を、さらなる公開のために調査します。
+  - Issue / MR の説明の履歴を確認します
+  - Advanced Search を使用して、GitLab チームメンバーが使用する他のプロジェクトで類似のパターンを探します
+
+### feature flag の背後にある機能のトリアージ
+
+研究者が[feature flag](https://docs.gitlab.com/ee/operations/feature_flags.html) の背後にある機能の脆弱性を報告することがあります。これらの報告は、デフォルト設定を使用する広範なオーディエンスに影響を与える前に脆弱性を修正できるため、優れたものです。これらの報告は算出されたバウンティの全額の対象となります。
+
+**注:** feature flag の背後にある機能は、しばしば Experimental または Beta ステージにあります。これらの機能の CVE 割り当てとブログ記事への含有に関するガイダンスについては、[Experimental および Beta 機能における脆弱性のトリアージ](#triaging-vulnerabilities-in-experimental-and-beta-features)を参照してください。
+
+`Attack Complexity` を判定するため、報告全体に注意を払います。以下の項目内の `complex` という用語は、[CVSS 3.1 仕様書](https://www.first.org/cvss/v3.1/specification-document)の **2.1.2 Attack Complexity** セクションで定義されているとおりです。前述のセクションでは **2.1.2 Attack Complexity** に以下のように記載されている点に留意してください — _**「攻撃が成功するために特定の合理的な構成が必要な場合、Base メトリクスは脆弱なコンポーネントがその構成にあると仮定してスコアリングすべきです」**_。
+
+- 複雑でない feature flag の背後にある機能の脆弱性は `AC:L` で支払われます (これは feature flag が脆弱なインスタンスで有効化されていると仮定した後)。ただし、トリアージと SLO のためには `AC:H` として処理します。
+- かなり複雑な feature flag の背後にある機能の脆弱性は依然として `AC:H` です (これは feature flag が脆弱なインスタンスで有効化されていると仮定した後)
+
+デフォルトで無効な feature flag の背後にある脆弱性には CVE は不要です (インポート時に `~no-cve` を使用)。これらは[セキュリティリリースではなく通常リリースでパッチされる](https://docs.gitlab.com/ee/administration/feature_flags.html#risks-when-enabling-features-still-in-development)ためです。
+
+### Experimental および Beta 機能における脆弱性のトリアージ {#triaging-vulnerabilities-in-experimental-and-beta-features}
+
+GitLab は、開発の Experimental または Beta ステージにある機能で発見された脆弱性に対して CVE 識別子を発行しません。これらの機能は、本番利用の準備ができていないと明示されており、オプトインでの有効化が必要であり、標準的な脆弱性修復 SLO に従いません。
+
+**機能の成熟度ステージの判定:** 機能の成熟度ステージを特定するには、[GitLab ドキュメント](https://docs.gitlab.com/) で機能を検索します。Experimental または Beta ステージの機能は、ドキュメントページの上部にステータスバナーを表示します (例: [GitLab Observability](https://docs.gitlab.com/operations/observability/) を参照)。ステータスバナーが存在しない場合、その機能は Generally Available とみなされます。
+
+Experimental または Beta 機能に影響する報告をトリアージする際:
+
+- `~no-cve` フラグを使用して報告をインポート: `/h1 import <report> [project] ~no-cve`
+- 重大度評価と修復のための通常のトリアージプロセスに従う
+- 脆弱性はセキュリティリリースのブログ記事には含めない
+- これらの機能には標準の修復 SLO は適用されない
+- Experimental または Beta ステータスの機能については、セキュリティ修正が canonical (公開で) リリースされる場合がある
+
+**根拠:** Experimental および Beta 機能には、CVE Records に必要な正式なバージョニング、サポートコミットメント、本番準備が欠けています。これらの機能をオプトインするユーザーは、[機能成熟度ポリシー](https://docs.gitlab.com/policy/development_stages_support/)に文書化されているとおり、関連するリスクを受け入れます。
+
+成熟度ステージの要件 (セキュリティに関するものを含む) の詳細については、[Development Stages Support ポリシー](https://docs.gitlab.com/policy/development_stages_support/) を参照してください。
+
+### 古い Ruby バージョンの Issue のトリアージ
+
+一部の脆弱性は特定の Ruby バージョンでのみ動作します。GDK を使用してローカルで再現するため、Ruby バージョンを変更する方法を以下に示します。
+
+1. 以下のファイル内の Ruby バージョンを必要なバージョンに更新します:
+   - `gitlab-development-kit/.tool-versions`
+   - `gitlab-development-kit/gitlab/.tool-versions`
+1. GDK ディレクトリ内で `asdf install ruby <required-version>` を実行します。
+1. GDK ディレクトリ内で `gem install gitlab-development-kit` を実行します。
+1. GDK ディレクトリ内の `./gitlab` ディレクトリに移動し、`bundle install` を実行します。
+1. `gdk restart` を実行して `https://127.0.0.1:3000/admin` にアクセスし、Ruby バージョンを確認します。
+
+### 非推奨機能のトリアージ
+
+非推奨機能の脆弱性は通常通りトリアージされます。詳細は[ディスカッション](https://gitlab.com/gitlab-com/gl-security/product-security/appsec/appsec-team/-/issues/336)を参照してください。
+
+### DNS レコードテイクオーバーのトリアージ
+
+DNS レコードテイクオーバーは通常、トリアージのために複数のチームを必要とします。ワークフローは少し異なります。
+
+- 該当ページ (または MX/TXT レコードの場合はサービス) を担当するチームにメンションする代わりに、SIRT と SRE Oncall と協力します
+- HackerOne 報告を `/h1 import $REPORT infrastructure` でインフラリポジトリにインポートします
+- Slack で `/security` を使用して SIRT を巻き込みます。これにより、SIRT がこの種類の攻撃に関連する調査業務を実行できるようになります。
+- Slack で `@sre-oncall` を巻き込みます。これにより、注意が必要な状況についてオンコール SRE に通知されます (PagerDuty ピンは送られません)。
+この脆弱性の修復は通常、ぶら下がっている CNAME レコードの削除を含みます。MX レコードのテイクオーバーに関する Issue については、通常、レコードの制御を取得するために MX SaaS ベンダーである Mailgun と協力します。MX レコードのテイクオーバーに関する詳細は[こちら](https://gitlab.com/gitlab-com/gl-security/product-security/appsec/appsec-team/-/issues/334)。
+
+### アワード
+
+- トリアージ時に授与されるバウンティ報酬の部分については、[GitLab の H1 ポリシー](https://hackerone.com/gitlab) の `Rewards` を参照してください
+  - トリアージ時のアワード付与を遅らせるのは構いません。例として、報告が意図された動作なのか、ドキュメントの変更になるかが不明な場合などです。必要であれば戻って部分授与を行うことを忘れないでください。
+  - トリアージ時に部分的なバウンティを授与した後、有効性または重大度の調整により過剰支払いだったと後で判明することは構いません
+- 報告に既存の council Issue がない場合、`/h1 bounty <report>` Slack ボットを使用して現在の[~"bug bounty council"](https://gitlab.com/gitlab-com/gl-security/security-department-meta/issues?scope=all&utf8=%E2%9C%93&state=opened&label_name[]=Bug%20Bounty%20Council) Issue にメモを投稿します
+  - 必要に応じて説明、類似 Issue、その他のコメントを追加します
+- アワードの承認:
+  - ドキュメント更新については、アワードはすぐに支払えます
+  - Low と Medium の CVSS については、少なくとも 1 名のチームメンバーが thumbsup 絵文字でリアクションした後にアワードを支払えます
+  - High と Critical の CVSS については、メモに 2 名のチームメンバーが thumbsup 絵文字でリアクションする必要があります
+  - 必要に応じて、メモに十分な票が集まっていない場合は `#sec-appsec-team-only` でリクエストします
+- Bug Bounty Council 承認後:
+  - canonical Issue で CVSS スコアと council 議論ポイントを説明することを検討します。これは、修復中にチームが重大度を理解するのに役立ち、Issue が公開された際には、研究者と顧客に対して特定のスコアに到達した方法の透明性を提供します。
+  - Issue がトリアージされてから 30 日が経過した場合、`04 - Bounty Award / Reviewed and Awarded Prior to Fix` common response を使用して、修正が確認される前に承認されたアワードを支払えます。
+  - 修正が出荷されたら、`02 - Bounty Award` common response を使用して残りの金額 (またはトリアージ時に何も授与されていなかった場合は全額) を授与します
+  - バウンティアワード支払い後、bug bounty council スレッドに 💰 絵文字を追加します。
+
+私たちのバグバウンティプログラムで金銭報酬の対象とならない品質の高い報告を提出した報告者には、[Contributor Success ストア](https://rewards.gitlab.com/)のクレジットを授与できます。
+クレジットを授与するには、Slack で Contributor Success チームに連絡してください。
+
+報酬クレジットには金銭的な価値はなく、GitLab Forest に木を植えることにも使用できます。これは、報告者がさまざまな理由でグッズや金銭報酬を受け取れない場合に役立ちます。クレジットの数は重大度によって異なるため、連絡時にこれを示してください。
+
+### Issue の管理
+
+脆弱性に関する議論と修復には、希望よりも長い時間がかかる場合があります。それでも、進捗が遅くても、報告者を放置するよりも頻繁にコミュニケーションを取ることがはるかに良いです。したがって:
+
+- 対応する GitLab Issue にマイルストーンが割り当てられると、自動プロセスが計画された修正日付で H1 報告にコメントを追加します。Issue が、Product Manager が Issue で @ メンションされてから **1 週間** 以内にマイルストーンに割り当てられない場合、product management チームにフォローアップしてください。
+- 修正が明確でない、またはパッチが作成されるかどうかについて議論が継続中の場合、報告者は少なくとも **月次で** 更新を通知されるべきです。
+- いずれにしても、過去 1 ヶ月以内に更新が提供されない「stale」状態になる報告があってはなりません。
+
+### SLA 例外
+
+HackerOne ボットは、インポートされた Issue の重大度に基づいて自動的に正しい期限を割り当てます。ただし、Issue がさまざまな理由でその期間内にパッチされない場合があります。これが発生した場合、開発チームは [SLA 例外](/handbook/security/product-security/vulnerability-management/sla/) を開き、Vulnerability Management チームによって承認されるべきです。Application Security チームはこれらの例外リクエストに関するガイダンスを提供することで支援可能ですが、開発チームがこれらのリクエストを提出し、正当性と例外タイプを提供することが期待されます。
+
+### Issue のクローズと公開 {#closing-out--disclosing-issues}
+
+パッチがリリースされ、アワードプロセスが完了したら、HackerOne Issue をクローズする時間です。
+
+30 日後、[セキュリティ Issue を公開するプロセス](/handbook/security/engaging-with-security/#process-for-disclosing-security-issues)に従います。
+これが完了したら、HackerOne Issue もケースバイケースで公開できます。機密情報を削除するための同じプロセスに従います。
+GitLab Issue が confidential のままである間は、HackerOne Issue を公開する、または公開を依頼すべきではありません。
+
+GitLab Security Bot (`@gitlab-securitybot`) によって行われたコメントは、PSIRT チームメンバーが `/h1 redact <comment_url>` Slack コマンドを使用して redact できます。
+
+他の研究者が品質の高い報告について学ぶのに役立つ HackerOne Hacktivity ページを作成するため、ユニークで興味深い解決済み報告の公開を歓迎します。
+
+研究者がクローズされた未解決の報告 (例: Informative または Not Applicable) の公開を要求する場合、`08 - Canceled Disclosure Message` テンプレートを使用して公開リクエストをキャンセルすることを選択します。報告者は代わりに [GitLab の公開 Issue を開く](https://about.gitlab.com/submit-feedback/)ことを検討すべきです。これは、脆弱性以外の Issue を提起し、対処する最良の方法です。
+
+研究者が HackerOne での公開を_主張する_場合、特に理由がない限り、品質に関係なく公開に同意すべきです。
+
+### severity::1/priority::1 Issue に関する PSIRT セキュリティエンジニア手順
+
+[severity::1/priority::1 Issue の取り扱い](/handbook/security/product-security/psirt/runbooks/handling-s1p1/)を参照してください。
+
+### Medium/Low 重大度の問題に関する PSIRT セキュリティエンジニア手順 {#psirt-security-engineer-procedures-for-mediumlow-severity-issues}
+
+HackerOne によってトリアージされ、Medium/Low 重大度として評価され、`GitLab Team` にアサインされた報告は、自動的に Issue としてインポートされます。報告に文書化されている脆弱な製品機能のそれぞれの EM/PM がコメントで通知されます。
+
+自動化により PSIRT エンジニアが council Issue に「imported by [engineer name]」としてアサインされ、Issue に対する所有権と説明責任が確立されます。アサインされたエンジニアは、CVSS スコアを検証し、必要に応じて適切なアクションを取る責任を負います。PSIRT エンジニアは、入ってくるアサインメントを監視するために、定期的に to-do リストをレビューすべきです。
+
+自動化によって作成された Issue の不正確さは、以下のラベルを適用することで追跡されます。
+
+- インポートされた GitLab Issue が誤った製品チーム/DRI にアサインされた場合、ラベル `H1-Assignment::Incorrect` を適用します
+- インポートされた GitLab Issue が偽陽性であると判定された場合、ラベル `H1-Status::FalsePositive` を適用します
+- インポートされた GitLab Issue が Bug Bounty プログラムのスコープ外であると判定された場合、ラベル `H1-Policy::OOS` を適用します
+- インポート後に PSIRT の介入が必要な場合、ラベル `H1-Escalation::PSIRT` を適用します
+
+### Informative、Not Applicable、または Spam として報告をクローズ {#closing-reports-as-informative-not-applicable-or-spam}
+
+報告が GitLab または GitLab ユーザーへのセキュリティリスクを引き起こさない場合、GitLab.com で Issue を開かずにクローズできます。
+
+これが発生した場合、なぜそれが脆弱性ではないかを研究者に通知します。報告を「Informative」、「Not Applicable」、または「Spam」のいずれとしてクローズするかは、Security Engineer の裁量に委ねられます。HackerOne はこれらの各ステータスに関して以下のガイドラインを提供しています。
+
+- Informative: 報告には有用な情報が含まれていたが、即時のアクションを保証しなかった。
+- Not Applicable: 報告が無効、不適格、または無関係だった。
+- Spam: 報告がセキュリティ問題を説明する正当な試みではない。
+
+私たちはほとんどの場合、GitLab へのセキュリティ影響がほとんどまたは全くない報告に対して「Informative」ステータスを使用し、セキュリティ概念の理解が乏しい報告や明らかにスコープ外の報告に対して「Not Applicable」を使用します。「Spam」は研究者の評判に最大のペナルティをもたらすため、明らかな悪用ケースでのみ使用すべきです。
+
+脆弱性ではない[再現可能なバグについては公開 GitLab Issue を開くこと](https://about.gitlab.com/submit-feedback/#reproducible-bugs)を提案するのが適切な場合があります。
+
+### 報告が不明確な場合 {#if-a-report-is-unclear}
+
+報告が不明確である場合、またはレビューアーが発見の有効性や悪用方法について質問がある場合は、今が質問する時です。研究者が発見の有効性と影響を判定するために必要なすべての情報を提供するまで、報告を「Needs More Info」状態に移動します。とにかく confidential Issue を開くことが理にかなっているかを判断するために、最善の判断力を使用してください。報告者からさらなる情報を求めていることをそこに記載します。迷った場合は、Issue を開く側に倒します。
+
+報告が明確化されたら、上記の「通常のフロー」に従います。
+
+### 効果的なコミュニケーションの破綻
+
+時には、報告者との効果的なコミュニケーションが破綻することがあります。これは複数の理由で発生する可能性がありますが、さらなるコミュニケーションが [GitLab の効果的かつ責任あるコミュニケーションのためのガイドライン](/handbook/communication/#effective--responsible-communication-guidelines)に従うことが重要です。報告者とのコミュニケーションがこの段階に達した場合、この目標を達成するために以下のステップを取るべきです。
+
+- 状況から一歩引きます。即座に応答しないでください。
+- H1 トリアージエンジニア、または、より楽な場合はマネージャーに、最善の進め方についてアドバイスを求めます。
+- 応答を複数回書くことを検討し、相談した人に応答をレビューしてもらいます。
+- 状況が落ち着いたら、一般的な状況が現在文書化されていない場合は、将来どのように対応できるかについてハンドブックへ MR を開きます。
+
+状況が行動規範違反につながる場合、行動規範違反の対処プロセスに従います。
+
+### Rules of Engagement または行動規範違反への対処 {#addressing-rules-of-engagement-or-code-of-conduct-violations}
+
+行動が私たちの[Rules of Engagement](https://hackerone.com/gitlab?type=team#user-content-rules-of-engagement-testing-and-proof-of-concepts)または HackerOne の[行動規範](https://www.hackerone.com/policies/code-of-conduct)に違反する場合、Bug Bounty Council を使用して私たちの応答を議論し、合意し、文書化します。Issue 説明にあるテンプレートを使用して現在の Bug Bounty Council Issue にコメントを追加します。
+
+私たちの透明性の価値観に沿って、なぜアクションを取ったのか、それらのアクションが何だったのかを研究者に説明するように努めるべきです。ただし、特定のケース (例: プログラム禁止) では、潜在的な虐待や報復からチームメンバーを安全に保つため、HackerOne にすべてのコミュニケーションを処理させるのが適切な場合があります。
+
+### 第三者に影響する可能性のある報告
+
+GitLab が HackerOne またはその他の手段で第三者に影響する可能性のある報告を受け取った場合、報告者はアップストリームに脆弱性を報告するよう奨励されます。緊急またはクリティカルな問題などのケースバイケースで、GitLab は、報告者に透明性を保ち、元の報告者がクレジットされることを確認しながら、セキュリティ問題をアップストリームに積極的に報告する場合があります。ただし、GitLab チームメンバーは、バグバウンティ関連の提出から観察された独自の手法を、影響を受ける可能性のある無関係な第三者に再適用することはありません。
+
+第三者ソフトウェアの脆弱性は、[HackerOne ポリシー](https://hackerone.com/gitlab?type=team)に記載されているとおり、以下のルールに従って受け入れられます。
+報告には、パッチがまだ利用できない新しい脆弱性が含まれている、または
+
+- パッチが 30 日以上利用可能である。
+- GitLab への影響を示す明確で動作する PoC がある。
+- GitLab への Critical または High の影響がある。
+
+これには、第三者ソフトウェアおよびサービスのウェブサイトは含まれず、依存関係とパッケージソフトウェアのみが含まれます。
+
+### HackerOne プロセスの FAQ とトラブルシューティング
+
+#### H1 報告を誤ってインポートしたらどうすればよいですか?
+
+関連性のないまたは実行不可能な (例: スコープ外、informative、または重複) H1 報告を誤ってインポートした場合:
+
+1. 結果として作成された Issue をクローズし、報告が誤ってインポートされたことを示すコメントを残します。
+1. 関連する CVE リクエスト Issue をクローズし、誤って作成されたことも記載します。
+1. 関連する HackerOne bug bounty council スレッドで、誤ったインポートを記載し、自動的に作成されたコメントに ❌ を追加し、スレッドを resolve します。
+
+#### CVE Issue が自動的に作成されたが CVE が発行されない状況はどう処理しますか?
+
+CVE リクエスト Issue が自動的に作成されたが CVE が発行されない場合:
+
+- なぜ CVE が発行されないのかを説明するコメントを CVE リクエスト Issue に追加します。
+- CVE リクエスト Issue をクローズします。
+
+#### 重複の H1 報告をインポートしたらどうなりますか?
+
+- Issue と関連する CVE リクエストまたは bug bounty council スレッドをクローズします。
+- 報告が重複であるため Issue と bug bounty council スレッドをクローズしているとコメントします。
+
+#### HackerOne 報告を再現できない場合はどうしますか?
+
+理想的には、報告された脆弱性を検証して再現してから製品チームを巻き込むべきです。
+PSIRT が Issue を再現できない場合、製品チームも再現できない可能性が高いです。脆弱性を確実に再現する手順がなければ、根本原因を特定し、意味のある修正を提案し、解決策が問題を完全に解決するかを検証することが困難になります。
+
+- 報告を検証した報告者または H1 triager に、再現手順が不明確または不足している場合は連絡します。
+- 最善の判断力を使用します。
+- 報告された脆弱性が特に深刻または影響力があるように見えるが、再現が困難な状況では、ピアに助けを求めてください。
+
+#### どの H1 報告が公開されませんか?
+
+GitLab 製品に影響し、CVE が発行されている脆弱性を公開します。
+
+GitLab ソフトウェア製品のソースコードを変更しても解決できない問題の報告で、CVE (CVSS 付き) が発行されないものは、通常公開されません。
+
+#### 報告者が別のスレッドで他の報告について尋ねた場合はどうしますか?
+
+私たちの HackerOne ポリシーには次のように記載されています:
+
+> The only appropriate place to inquire about a HackerOne report's status is on the report itself. Please refrain from submitting your report or inquiring about its status through additional channels including any other unrelated HackerOne report, as this unnecessarily binds resources in the security team.
+
+そのため、報告者が報告を使用して別の報告のステータスについて尋ねた場合、「Common Responses」の `51 - Reminder for asking about other reports` テンプレートを使用して応答します。
+
+### Ultimate ライセンスの授与
+
+3 件以上の有効な報告を行った GitLab 報告者は、最大 5 ユーザーの 1 年間 Ultimate ライセンスの対象となります。[H1 ポリシー](https://gitlab.com/gitlab-com/gl-security/hackerone/configuration/-/blob/master/program-policy.md#gitlab-ultimate-license)のとおり、報告者は自分の Issue の 1 つにコメントしてライセンスをリクエストします。報告者がライセンスをリクエストした場合、以下のステップを取るべきです。
+
+1. 3 件の報告が有効であったことを検証します。これは、`Triaged` または `Resolved` であることを意味します。
+1. 3 件の報告が以前のライセンスを取得するために使用されていないことを検証します。
+1. 報告が有効でない場合、ライセンスが発行されない理由を説明して H1 で報告者に応答します。
+1. 報告が有効である場合、Zendesk Global アカウント (お持ちでない場合は[こちら](../../../../support/internal-support/_index.md#requesting-a-zendesk-light-agent-account)からリクエストできます) を使用してログインし、[Submit a request](https://gitlab-internal.zendesk.com/hc/en-us/requests/new?ticket_form_id=22783840298780) フォームに移動してください:
+    - `Choose the reason why you are reaching out to us today` には **L&R Internal Request** デフォルトオプションを保ちます
+    - `What category of request?` ではまず **Other** を選択し、次に **Hacker One Reporter license** を選択します
+    - `What expiration date should be used?` には、リクエスト日からちょうど 1 暦年後の日付を選択します
+    - `What is the contact's name?` には、利用可能であれば報告者のフルネームを使用し、そうでなければ H1 ハンドルを使用します
+    - `What is the contact's email?` には、報告者の `[username]@wearehackerone.com` メールアドレスを使用します
+1. 関連するライセンス情報を [H1 License Award シート](https://docs.google.com/spreadsheets/d/1qJZ9jfIvQuSU5u4odj4Db_CRKJ_GHegtSZQvJx36FUE/edit)に入力します
+1. `20 - Ultimate License Creation` テンプレートを使用して H1 で報告に返信します。
+
+ライセンスは CustomersDot から報告者に送信されます。報告者がライセンスが届いていないと主張する場合、アプリを使用してライセンスを再送信できます。
+それが発生した場合、新しいライセンスの作成は避けるべきです。
+
+### 質問?
+
+一般のメンバーは、こちらで私たちのバグバウンティプログラムについて質問できます: [https://gitlab.com/gitlab-com/gl-security/product-security/appsec/hackerone-questions/](https://gitlab.com/gitlab-com/gl-security/product-security/appsec/hackerone-questions/)。このリポジトリは報告と脆弱性を議論または開示する場所では**ありません**ので注意してください。
+
+### HackerOne トリアージチーム GitLab ライセンス
+
+HackerOne トリアージチームのすべてのメンバーは GitLab Ultimate ライセンスにアクセスできます。HackerOne は、ライセンスの更新が必要な時期について毎年通知します。
+
+- [Zendesk ポータル](https://gitlab-internal.zendesk.com/hc/en-us/requests/new?ticket_form_id=22783840298780)にアクセスします
+  - `Choose the reason why you are reaching out to us today` には **L&R Internal Request** デフォルトオプションを保ちます
+  - `What category of request?` ではまず **Other** を選択し、次に **Hacker One Reporter license** を選択します
+  - `What expiration date should be used?` には、リクエスト日からちょうど 1 暦年後の日付を選択します
+  - `What is the contact's name?` には "HackerOne analysts" を使用します
+  - `What is the contact's email?` には `analysts@h1triage.com` を使用します
+
+- 説明には、以下を貼り付けます:
+
+```text
+A new license is needed for our HackerOne Triage+ team. This team helps us triage HackerOne reports and will need a license with 50 users each. They need an ultimate license to validate reports affecting any feature of the product.
+
+The license should be sent to: analysts@h1triage.com
+
+Company: HackerOne Inc.
+
+License type: Ultimate
+
+Number of users for each license: 50
+
+License duration: 1 year
+```

--- a/content/handbook/security/product-security/psirt/runbooks/handling-s1p1.md
+++ b/content/handbook/security/product-security/psirt/runbooks/handling-s1p1.md
@@ -1,0 +1,117 @@
+---
+title: "priority::1/severity::1 Issue の取り扱い"
+upstream_path: /handbook/security/product-security/psirt/runbooks/handling-s1p1/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+以下のプロセスは、[クリティカルリリースプロセス](https://gitlab.com/gitlab-org/release/docs/blob/master/general/security/process.md#critical-security-releases)の最初の数ステップを補完するものです。
+
+潜在的な severity::1/priority::1 Issue が判明した時点で、PSIRT エンジニアの手順は以下のとおりです。
+
+## トリアージ
+
+1. 通常の[レポートのトリアージ](/handbook/security/product-security/psirt/runbooks/hackerone-process/)と同じように、Issue をトリアージし検証します。
+1. SIRT チームを巻き込む前に、Bug Bounty Council (BBC) スレッドで複数のチームメンバーの投票を経て、セキュリティ Issue の CVSS スコアを確定します。時間的制約を考慮し、議論には同期通話または Slack の利用を検討してください。議論の結果は BBC スレッドに記録します。地域内の PSIRT チームメンバーが PTO 中であったりタイムゾーンの問題で同期通話や Slack ディスカッションが不可能だった場合は、Issue がトリアージされてから 4 時間が経過した時点で SIRT ワークフローを起動してください。
+1. BBC スレッド内で、GitLab Dedicated 固有の CVSS スコアを作成します。
+1. SecOps が影響範囲とログ分析を迅速に判断できるよう、再現手順の概要 (HTTP リクエスト、生成されたログメッセージ、画像など) をセキュリティ Issue にコメントします。
+1. エスカレーション後、即時に脆弱な他のコンポーネントや別の影響がないかどうか調査します。
+
+## エスカレーション
+
+1. Issue へのリンク、現状のサマリー、SIRT に必要となる対応の概要を添えて、[セキュリティオンコールエンジニアを巻き込みます](/handbook/security/security-operations/sirt/engaging-security-on-call/)。
+1. 影響を受けるコンポーネントの担当 [Engineering Manager と Product Manager](/handbook/product/categories/) を、Issue 内**および**該当する Slack チャンネル両方で巻き込みます。
+1. GitLab Dedicated チームの支援が必要な場合は、[オンコールエンジニアへエスカレーションするためのランブック](https://gitlab-com.gitlab.io/gl-infra/gitlab-dedicated/team/runbooks/on-call.html#escalating-to-an-on-call-person)に従ってください。
+1. `#security_help` Slack チャンネルで `@appsec-leadership` に Issue へのリンクとともにメンションします。これにより、チームのリーダー陣や他のエンジニアが状況を把握でき、必要に応じて介入できます。
+1. CVSS 評価と議論の参照および正典として、SIRT Tines ケースに Bug Bounty Council の CVSS ディスカッションへのリンクを追加します。
+1. インシデント専用の Slack チャンネルに、CVSS の bug bounty council ディスカッション Issue へのブックマークを作成します。
+
+## 異なる環境における影響評価
+
+GitLab self-managed、GitLab Dedicated、GitLab SaaS (GitLab.com) の間では、設定・機能の利用可否・構成が異なるため、単一の脆弱性であっても CVSS は環境ごとに異なる可能性があります。
+
+セキュリティ脆弱性の悪影響を正確に伝え効果的に緩和するためには、特に攻撃が成立するために特定の前提条件が必要となる場合、各環境の設定・機能可否・構成における差異を考慮してください。
+
+### GitLab Dedicated
+
+GitLab の脆弱性が GitLab Dedicated に影響するかを評価する際は、[GitLab Dedicated で**利用できない**](https://docs.gitlab.com/ee/subscriptions/gitlab_dedicated/#features-that-are-not-available)以下の機能を考慮してください。
+
+#### GitLab Dedicated で利用できないアプリケーション機能
+
+- [ ]  LDAP、Smartcard、または Kerberos 認証
+- [ ]  複数のログインプロバイダー
+- [ ]  Advanced Search
+- [ ]  GitLab Pages
+- [ ]  Reply-by email
+- [ ]  Service Desk
+- [ ]  FortiAuthenticator または FortiToken 2FA
+- [ ]  GitLab マネージドランナー (ホストランナー)
+- [ ]  GitLab AI 機能 ([詳細情報](https://about.gitlab.com/direction/gitlab_dedicated/#supporting-ai-features-on-gitlab-dedicated))
+- [ ]  GitLab UI の外で構成する必要がある機能 (デフォルトで無効化されている [feature flag](https://docs.gitlab.com/ee/user/feature_flags.html) の背後にあるものを含む)
+- [ ]  Mattermost
+- [ ]  サーバーサイド Git フック (セキュリティ上の懸念とサービス SLA への影響の可能性のため。代替として[プッシュルール](https://docs.gitlab.com/ee/user/project/repository/push_rules.html)や [Webhook](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html) の利用を検討してください。)
+
+ある脆弱性の悪用が上記の機能の使用を必要とする場合、GitLab Dedicated には**影響しない**可能性が高いです。正確な評価のため、必ず脆弱性の具体的な詳細とクロスチェックしてください。
+
+## 緩和
+
+クリティカルなセキュリティ Issue の緩和は、GitLab とユーザーをできるだけ早く保護することと、すぐに別のパッチを必要としない信頼性の高い方法で実施することのバランスを取る必要があります。
+パッチはまず GitLab マネージド環境 (.com、Dedicated など) に展開され、その後 self-managed ユーザーへリリースされます。
+
+1. すべての関連チーム (該当機能を所有する開発チーム、インフラ、SIRT など) と協力して、脆弱性に対する解決策を策定します。
+1. 各オプションの影響を分析します。
+    - 問題解決にどれほど効果的か?
+    - 症状を抑えているのか、根本原因を修正しているのか?
+    - この決定により何人の顧客が影響を受けるか?
+    - 具体的にどのように影響を受けるか?
+    - その規模はどの程度か?
+    - その他、どのような肯定的・否定的な結果があるか?
+1. 上記の懸念事項と関与するチームの懸念事項のバランスを最も取れる解決策を選択します。
+1. 解決策が提供された後、修正が有効であることを検証します。
+
+時には、適切なパッチを十分に開発・レビューする前に、応急的な修正が必要となることがあります。
+過去に使用した短期的なオプションの例を挙げます。
+
+- 特定のエンドポイントをブロックする Cloudflare ルール。
+- feature flag やアプリケーション設定を使用して特定の機能を無効化する。
+- [hotpatch](https://gitlab.com/gitlab-org/release/docs/blob/master/general/deploy/post-deployment-patches.md) を展開する。
+
+### self-managed 顧客へのリリース
+
+隔週のリリーススケジュールに移行して以降、[クリティカルセキュリティリリースワークフロー](https://gitlab.com/gitlab-org/release/docs/blob/master/general/security/security-engineer.md##critical-security-releases)に従ってクリティカルな脆弱性をパッチする必要性は大幅に減少しました。
+通常のパッチリリースに含めるか、クリティカルセキュリティリリースを実施するかの判断には、多くの要因を考慮する必要があります。
+それらの要因には、以下のようなものが含まれますが、これらに限定されません。
+
+- この脆弱性はどれほど容易に悪用できるか?
+- 脆弱性の悪用にユーザーアカウントが必要か?
+- 脆弱性は実環境で悪用されているか?
+- 攻撃を自動化し、大規模に容易に悪用できるか?
+- 脆弱性の影響度はどの程度か?
+
+これはケースバイケースで対応され、状況が発生するたびにすべてのステークホルダーと評価する必要があります。
+アドホックなクリティカルセキュリティリリースを選択する可能性が非常に高いシナリオの例:
+
+- 実環境で悪用されている、未パッチの critical 重要度の脆弱性 (CVSS 9 以上)
+- PoC や悪用コードが公開されている、未パッチの critical 重要度の脆弱性 (CVSS 9 以上)
+- CVSS 10.0 の脆弱性 (例: 認証不要の RCE や管理者アカウント乗っ取り)
+
+## RCA の開始
+
+製品の脆弱性であれば、PSIRT の DRI はできるだけ早く [Root Cause Analysis (RCA) 調査 Issue を開始](/handbook/security/root-cause-analysis/#initiating-an-rca)する必要があります。バイパスや類似インシデントを防ぐため、脆弱性の根本原因を十分に理解し文書化することは極めて重要です。このステップの結果として、フォローアップの予防的・緩和的コントロールに関する Issue が作成され優先順位付けされます。
+
+## ハンドオフ
+
+PSIRT エンジニアはオンコール体制ではありません。つまり、担当の PSIRT エンジニアの就業時間が終了する際は、後続のタイムゾーンの PSIRT エンジニアに引き継ぐ責任があります。
+
+現状のサマリーと、PSIRT に必要となる残課題・今後のタスクを簡潔に提供します。SIRT Tines ケース、コミュニケーションドキュメント、Slack リンクなどの有用なリンクも提供します。理想的には、引き継ぎ相手と議論や質問対応を行うため、短い同期通話もスケジュールします。
+
+ハンドオーバーが行われたことをインシデント関連の Slack チャンネルで共有し、`#security_help` などの他の関連チャンネルにもクロスポストします。以下のようなメッセージテンプレートが適切な場合があります。
+
+> 🤝 PSIRT Handover 🤝  I have handed over to `@username` for any PSIRT needs, as I am close to the end of my working day. [Include details on how we will continue to deliver on any tasks that PSIRT is DRI for].
+
+### Family and Friends Day カバレッジ
+
+[Family and Friends Day](/handbook/company/family-and-friends-day/) は、GitLab が公式に休業する日です。
+詳細は[休日カバレッジ](/handbook/security/product-security/security-platforms-architecture/application-security/runbooks/holiday-coverage/)を参照してください。

--- a/content/handbook/security/product-security/psirt/runbooks/holiday-coverage.md
+++ b/content/handbook/security/product-security/psirt/runbooks/holiday-coverage.md
@@ -1,0 +1,44 @@
+---
+title: "PSIRT の祝日および Friends and Family Day カバレッジ"
+upstream_path: /handbook/security/product-security/psirt/runbooks/holiday-coverage/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+このランブックは、Product Security Incident Response Team が祝日・Friends and Family Day・その他多くのチームメンバーが不在となるイベント期間中に、対応可能なメンバーを確保するためのプロセスを説明します。
+
+PSIRT はオンコール体制ではないため、地域ごとに必ずしもカバレッジを提供できるとは限らない、ベストエフォート方式での対応を目指します。
+
+支援が必要な場合:
+
+- `#security_help` に詳細を投稿する
+- カバレッジを提供している PSIRT エンジニアを探す — 後述の[カバレッジの周知](#communicating-the-coverage)を参照
+- Slack の `@` メンションでチームメンバーに連絡する
+- 緊急の場合や、チームメンバーから適時に応答がない場合は、Slack プロフィールに記載されている連絡先設定を確認したうえで、テキストメッセージや電話で連絡する
+- 誰がカバレッジを提供しているのか不明な場合は、Slack で `@psirt-team` にメンションする
+
+## カバレッジを担当する人への期待事項
+
+- PSIRT が S1 インシデントに対応する必要が生じた場合、または他チームの緊急支援が必要となった場合に、カバレッジを担当しているチームメンバーは Slack または電話で連絡が取れる状態であること
+- カバレッジを担当している PSIRT チームメンバーは、キーボードに向かって作業している必要はありませんが、必要に応じて 1 時間以内にオンラインに復帰できる状態であること
+- カバレッジ時間中に積極的に作業していない場合でも、ピンに備えて時々 Slack を確認するように努めること
+- HackerOne 経由で来る可能性のある S1 を時々チェックし、即時対応が必要な場合はアクションを取ること
+- S1 インシデントが発生した、または他チームから PSIRT への緊急支援要請があった場合、PSIRT チームメンバーは状況を切り分け、必要に応じてセキュリティマネージャーへエスカレーションすることが期待される
+
+## 計画
+
+祝日や Friends and Family Day が近づいた場合、PSIRT チームは休日を交代できるチームメンバーを探すように努めます。理想的には各地域に 1 名のチームメンバーが対応可能であることが望ましいですが、必須ではありません。
+
+[Rotation Management](https://gitlab.com/gitlab-com/gl-security/product-security/appsec/tooling/rotation-management) Issue トラッカーを使用してカバレッジを割り当て・調整してください。
+
+## カバレッジの周知 {#communicating-the-coverage}
+
+[HackerOne Triage Rotation](/handbook/security/product-security/security-platforms-architecture/application-security/runbooks/triage-rotation/) ハンドブックページに、ローテーションと割り当てに関する情報が記載されています。
+
+PSIRT チームは `#security_help` に Slack メッセージを投稿し、誰がいつ対応可能か、PSIRT の緊急支援が必要な場合の連絡方法を周知します。可視性向上のため、`#security` および `#security-division` チャンネルにもクロスポストしてください。
+
+カバレッジを提供する各 PSIRT チームメンバーは、Slack プロフィールに自分の携帯電話番号を記載しておきます。
+
+インシデントが発生した場合は、["S1/P1 対応手順"](/handbook/security/product-security/psirt/runbooks/handling-s1p1/)に従ってください。次の PSIRT エンジニアへの引き継ぎも含まれます。

--- a/content/handbook/security/product-security/psirt/runbooks/psirt-case-lifecycle.md
+++ b/content/handbook/security/product-security/psirt/runbooks/psirt-case-lifecycle.md
@@ -1,0 +1,157 @@
+---
+title: "PSIRT ケースライフサイクル"
+description: PSIRT がケースをどのように管理するかの説明
+upstream_path: /handbook/security/product-security/psirt/runbooks/psirt-case-lifecycle/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+最終更新: 2025年12月3日
+
+## PSIRT ケースライフサイクルについて
+
+PSIRT のアナリストとエンジニアは、GitLab の製品・サービス・インフラ内のセキュリティ脆弱性に関する報告を協力して調査します。すべての有効な報告について、PSIRT は Engineering と協力して修復を相談し、Delivery と協力して必須のセキュリティ更新について顧客に通知します。
+
+PSIRT は以下のソースからの報告を調査します。
+
+- HackerOne
+- 顧客
+- VAT
+- 公開情報・ニュース
+- 実証可能な悪用が伴うセキュリティツール
+- 内部セキュリティリサーチ
+
+PSIRT は、クリティカルな脆弱性が積極的に悪用されている、または公に知られている場合にインシデントを起こします。PSIRT が GitLab のインシデントプロセス内でどのように動作するかの詳細は、ハンドブックに掲載され次第 [Unified Incident Severity Matrix](/handbook/engineering/infrastructure-platforms/incident-management/#severities) を参照してください。それ以外の場合、報告は調査・記録され、定められた SLA 内で修復されます。
+
+## PSIRT ケース調査
+
+PSIRT ケースには 6 つのステージがあります。最初の 2 つのステージ (トリアージとアセスメント) は PSIRT 内で完了し、後半の 4 つのステージは Engineering および Delivery の複数チームと部門横断的に作業を行います。
+
+**注:** PSIRT のトリアージプロセスは、HackerOne ケースの Triage ステージとは対応していません。
+
+| ステージ | トリアージ | アセスメント | 修復 | 検証 | リリース | リリース後 |
+| :---- | :---- | :---- | :---- | :---- | :---- | :---- |
+| **担当** | Security Analyst (SA) | Security Engineer (SE) | SA & SE | Security Engineer (SE) | SA & SE | Security Analyst (SA)  |
+| **内容** |  完全なアセスメントが必要かを判定するためのケース初期レビュー。  | プラットフォームごとの完全な検証とアセスメント。影響、再現手順、CWE、CVSS、影響を受けるバージョン、重大度を含む。 | SE: Engineering との Issue 相談および追加のバリアントハンティング SA: ケースの SLA および Heightened Watch 基準のモニタリング | SE: 修正の十分性を判断するためのレビュー | セキュリティリリースブログ記事による修正のリリースおよび顧客への通知  | 月次/四半期レポートの完了 クリティカルなものは、レトロおよび経営報告の完了。 |
+| **想定される結果** | 無効 PSIRT エンジニアによる完全アセスメント Heightened Watch 付き PSIRT エンジニアによる完全アセスメント SIRT への引き継ぎ Vulnerability Management への引き継ぎ  | 無効 Engineering 向けに不具合をファイル Heightened Watch 付き Engineering 向けに不具合をファイル PSIRT/SIRT 共同インシデント  | バリアント発見と Issue ファイル 緩和策とワークアラウンド発見  追加情報なし Heightened Watch を PSIRT/SIRT 共同インシデントへエスカレーション | 修正なし: Engineering によるリスク受容 修正の MR を承認 修正の MR を却下  | 該当なし |  |
+| **HackerOne ケース状態** | New <br/> Pending Program Review | Pending Program Review | Triaged | Triaged | Triaged | Closed |
+
+### SLO
+
+脆弱性のトリアージ、アセスメント、リリース後レポートに関して以下の SLO を設定しています。
+
+| | Critical/High | Medium | Low |
+| :---- | :---- | :---- | :---- |
+| トリアージ | 5 日 | 5 日 | 5 日 |
+| アセスメント | トリアージ引き継ぎから 10 日 | トリアージ引き継ぎから 20 日 | トリアージ引き継ぎから 20 日 |
+| リリース後 | リリースから 15 日 | リリースから 30 日 | リリースから 30 日 |
+
+## PSIRT トリアージワークフロー
+
+PSIRT のトリアージワークフローは、重大度と特性に基づいて、システムを通じて脆弱性を正確に初期評価し、適切にルーティングすることを保証します。
+
+以下のワークフローは PSIRT の対応範囲内のすべての報告に適用されますが、[HackerOne 報告](/handbook/security/product-security/psirt/runbooks/hackerone-process/)にのみ該当する手順を含む場合があります。
+
+1. [HackerOne](https://hackerone.com/bugs?organization_inbox_handle=gitlab_inbox&assigned_to_group_ids%5B%5D=108264&text_query=&end_date=&reported_to_team=&sort_direction=descending&sort_type=latest_activity&start_date=)、メール、Slack で新規報告を監視します。
+2. 受領確認
+   - 発見者に脆弱性報告の受領を確認します
+3. 完全性チェック
+   - 報告を評価し、進めるための十分な詳細があるかを判定します
+   - 不完全な場合: 続ける前に発見者に追加の詳細を求めます
+4. 引き継ぎの確認
+   - Vulnerability Management への引き継ぎ
+     1. 報告がクリティカルではなく GitLab 固有の POC がない、公開済み CVE に関するものである場合、Known Exploited Vulnerabilities リストを確認します
+     2. [KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) に掲載されていない場合: Vulnerability Management に引き継ぎます
+   - SecOps への引き継ぎ:
+     1. 報告がクリティカルで KEV リストに掲載されている公開済み CVE のものである場合、Heightened Watch を発動します
+     2. 報告が SecOps の対応範囲内であれば、SecOps に引き継ぎます
+5. 残りの報告について、Slack の Import 手順を使用して GitLab Issue を作成します
+6. 報告を検証する
+   - 報告をレビューし、潜在的な脆弱性があるかを判定します
+   - 無効な場合: Issue 報告者に通知し、必要に応じて報告を更新したうえで、対応を打ち切ります
+   - 報告が潜在的に有効である場合、重大度レベル (Critical、High、Medium、Low) を分類し、Issue の Triage Assessment セクションを完成させます
+7. Security Engineer に割り当てる
+8. (HackerOne) 追加の詳細や更新依頼がないか報告を監視する
+
+## PSIRT アセスメントワークフロー
+
+アセスメントフェーズは主に技術評価期間で、PSIRT エンジニアが詳細な分析を行いつつ、必要に応じてインシデント対応や専門知識のために他チームとの調整を維持します。
+
+### PSIRT エンジニアのタスク
+
+1. アサイン後、技術的脆弱性分析を完了する
+   - 脆弱性の再現: 報告された脆弱性を確認し再現する
+   - プラットフォームとバージョンの特定: 影響を受けるすべてのプラットフォームとバージョンを判定する
+   - 悪用可能性の調査: 脆弱性がどれほど容易に悪用できるかを評価する
+   - 重大度評価: 技術的な重大度レベルを評価する
+   - 影響分析: STRIDE 手法によるアセスメントを行いセキュリティ影響を理解する
+   - CVSS スコアリング: Common Vulnerability Scoring System のスコアを算出する
+   - CWE 分類: 適切な [Common Weakness Enumeration](/handbook/engineering/development/sec/secure/products/metrics/) カテゴリを割り当てる
+2. すべての発見と技術的詳細を PSIRT 調査 Issue に記録する
+   - GitLab に影響がない場合、理由を特定し、発見者へのフォローアップのために Security Analyst にアサインする
+   - GitLab に影響がある場合、アセスメントを完了して Engineering の修復用に Issue をファイルし、Security Analyst にバウンティ支払いと HackerOne 報告の Triaged 状態への移行を依頼する
+3. IOC 分析: Issue がクリティカルである場合、Indicator of Compromise が特定できるかを判定する
+   - Indicator of Compromise が特定できる場合、SIRT が IOC 悪用マーカーを探すために PSIRT/SIRT 共同調査を開始する
+   - 悪用が示唆される場合、SIRT インシデントを起こす
+   - それ以外の場合、Heightened Watch を実施する
+
+### PSIRT アナリストのタスク
+
+1. バウンティおよび管理タスクを完了する
+   - GitLab に影響がない場合、発見者にフォローアップする
+   - GitLab に影響がある場合:
+     - HackerOne 報告については、適切なバウンティを支払い、HackerOne で Issue を Triaged 状態に移行する
+     - その他の報告については、発見者にフォローアップする
+   - Heightened Watch の場合、インシデントへのエスカレーションを監視する
+
+## PSIRT 修復ワークフロー
+
+### PSIRT エンジニアのタスク
+
+1. 修復と並行して:
+   - バリアントハンティング: 関連する脆弱性や攻撃ベクトルを探索する
+   - 緩和策の特定: 潜在的な緩和策とワークアラウンドを特定する
+
+### Breaking Change の取り扱い
+
+破壊的変更のリスクがある解決策を評価する際、PSIRT エンジニアは以下を確認し支援する必要があります。
+
+- この解決策はデフォルトで安全か?
+- [breaking change テンプレート](https://gitlab.com/gitlab-com/Product/-/blob/main/.gitlab/issue_templates/Breaking-Change-Exception.md?ref_type=heads)に従って、PSIRT は以下の領域で支援できます。
+  - _Executive Summary_ セクション: PSIRT は、破壊的変更が「_significant security risk - Severity 1 or 2_」基準に該当するかを確認する自然な所有者です。チームは重大度評価を検証し、セキュリティ上の正当性を確認すべきです。
+  - _"Can we get the same outcome without a breaking change?"_ セクション: PSIRT は、破壊的変更を回避する代替修正案が存在するかについて意見を提供したり、破壊的アプローチが唯一の実行可能な修復策であることを確認したりできます。
+  - _"When do you want to make the breaking change?"_ セクション: PSIRT は、特に脆弱性 SLA や FedRAMP 修復期限がタイムラインを制約する場合、タイミングについて意見を述べるべきです。
+  - _Customer Communication_ セクション: PSIRT は、顧客向け文言が脆弱性の詳細を過剰に開示しないようにしつつ、なぜ破壊的変更が必要なのかを十分に説明していることをレビューすべきです。また、セキュリティリリースブログ記事と一般的な破壊的変更の通信との調整の問題もあります。
+  - _Deprecation issue linkage_ セクション: テンプレートには、VP の承認後に公開のデプリケーション Issue を作成すると書かれています。セキュリティに動機づけられた変更については、PSIRT が公開 Issue に何が記載されるかをレビューし、早期開示を防ぐべきです。
+
+## PSIRT 検証ワークフロー
+
+検証フェーズは、リリースプロセスに進む前に脆弱性が適切に解決されていることを保証する品質ゲートとして機能します。修復と検証のフェーズはループで動作します — 検証中に修正が不十分と判定された場合、プロセスは Engineering の修復に戻り、修正が完全かつ十分とみなされるまで追加の作業が行われます。
+
+### PSIRT エンジニアのタスク
+
+1. MR レビューで[修正を検証する](/handbook/security/product-security/psirt/runbooks/verifying-security-fixes/)
+   - 修正が不適切な場合、MR を却下する
+   - 修正が不適切な場合、MR を承認し、影響を受けるプラットフォーム、バージョン、重大度、CWE、CVSS スコアを確認する
+
+## PSIRT リリースワークフロー
+
+パッチリリースはエンジニアとアナリストの共同責任です。
+一般情報については[パッチリリースにおける Product Security Incident Response Team の一般的なプロセス](/handbook/security/product-security/psirt/runbooks/security-engineer/)を、具体的な手順については [PSIRT パッチリリース業務](https://internal.gitlab.com/handbook/security/product_security/psirt/runbooks/security_release/)を参照してください。
+
+## PSIRT リリース後ワークフロー
+
+リリース後タスクはエンジニアとアナリストの間で共有されます。
+
+### PSIRT エンジニアのタスク
+
+1. リリースが正常に完了したことを確認する。
+2. Release Retro Issue を作成または貢献する。
+
+### PSIRT アナリストのタスク
+
+1. Issue がクリティカルな場合、レトロスペクティブをスケジュールし、経営報告を準備します。Issue が SIRT/PSIRT の共同責任であった場合は、SIRT と連携して作業します。
+2. [Release Retro Issue](https://gitlab.com/gitlab-com/gl-security/product-security/appsec/appsec-team/-/issues/new?description_template=release_retro) を作成または貢献します。
+3. Monthly Business Report に追加します (TBD)。
+4. HackerOne 報告がクローズされていることを確認します。

--- a/content/handbook/security/product-security/psirt/runbooks/security-engineer.md
+++ b/content/handbook/security/product-security/psirt/runbooks/security-engineer.md
@@ -1,0 +1,10 @@
+---
+title: パッチリリースにおける Product Security Incident Response Team の一般的なプロセス
+upstream_path: /handbook/security/product-security/psirt/runbooks/security-engineer/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+{{% include-remote "https://gitlab.com/gitlab-org/release/docs/-/raw/master/general/security/security-engineer.md" 1 %}}

--- a/content/handbook/security/product-security/psirt/runbooks/unintended-vuln-disclosure.md
+++ b/content/handbook/security/product-security/psirt/runbooks/unintended-vuln-disclosure.md
@@ -1,0 +1,108 @@
+---
+title: 意図しない脆弱性開示の取り扱い
+summary: 意図しない脆弱性開示の様々なシナリオに対応するためのランブック。
+upstream_path: /handbook/security/product-security/psirt/runbooks/unintended-vuln-disclosure/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 概要
+
+未修正の (または不十分にしか修正されていない) 脆弱性に関する詳細が、意図せず公開されてしまう状況があります。このランブックには、こうした状況で AppSec が従うべき具体的なプロセスを含みます。
+
+## SIRT への呼び出し手順
+
+以下に概要を示す SIRT を呼び出すアクションでは、~severity::4 を超える重大度の Issue について「page immediately」のチェックボックスをオンにしてください。
+
+### canonical でセキュリティミラーではなく修正された脆弱性
+
+#### 即時対応
+
+1. セキュリティ Issue が公開で対応してよいかを確認します。これは通常 ~"security-fix-in-public" ラベルで示されており、このラベルがない場合は次のステップに進みます。
+1. AppSec エンジニアは Slack で `/security` を使用して SIRT を呼び出すべきです。
+
+#### 緩和
+
+1. SIRT が[コミットクリーンアップ](https://internal.gitlab.com/handbook/security/security_operations/sirt/operations/ttps/procedures/accidental_commit_cleanup/)を実行します。
+
+#### フォローアップアクション
+
+1. SIRT は脆弱性に対する積極的な悪用試行を監視するためにモニタリングを実行します。
+
+### 別の関連する脆弱性の不十分な修正
+
+#### 即時対応
+
+1. 脆弱性がクリティカルな場合、SIRT が検出と緩和の作業を開始できるよう、/security 経由で SIRT を呼び出す必要があります。
+1. AppSec は、適切な priority と severity ラベルを付けて新しい Issue を作成すべきです。即座に対応できるよう、適切な EM/PM にメンションすべきです。
+
+#### 緩和
+
+1. 他の脆弱性報告と同様。
+
+#### フォローアップアクション
+
+1. 修正が公開後すぐに不十分であると判明した場合、その機能に対して [AppSec レビュー](/handbook/security/product-security/security-platforms-architecture/application-security/runbooks/review-process/)を開くことを検討します。
+1. 修正が不十分だった理由を解明するため、[RCA Issue](/handbook/security/root-cause-analysis/) を開くことを検討します。
+
+### HackerOne 報告者が修正前に何かを公開すると決定した場合
+
+#### 即時対応
+
+1. AppSec エンジニアは即座に Slack で `/security` を使用して SIRT を呼び出すべきです。
+
+#### 緩和
+
+1. 開発者が脆弱性の修正を優先して取り組むよう促すため、SLA ウィンドウを引き上げます。
+1. 脆弱性の重大度に応じて、通常または重要なセキュリティリリースのスケジューリングを検討します。
+
+#### フォローアップアクション
+
+1. [行動規範違反](/handbook/security/product-security/psirt/runbooks/hackerone-process/#addressing-rules-of-engagement-or-code-of-conduct-violations)プロセスに従って、HackerOne 研究者をプログラムから禁止します。
+1. `#legal` Slack チャンネルまたは Issue へのメンションで Legal チームに状況を伝え、法的観点から (もしあれば) どのような措置を取るべきかを判断してもらいます。
+1. 影響を受ける可能性のある顧客に警告するため、Communications を関与させます。
+
+### コミュニケーションミスやその他の意図しない漏洩
+
+以下について:
+
+- YouTube 動画でメール受信箱の漏洩により Issue タイトルが公開されてしまった
+- コミュニティメンバーや顧客に誤って情報を渡しすぎた
+
+#### 即時対応
+
+1. 攻撃者が脆弱性を悪用するための PoC を構築するのに十分な情報が漏洩したかを判断します。漏洩した場合、Slack で `/security` を使用して SIRT を呼び出します。
+
+#### 緩和
+
+1. [これらの手順に従って YouTube 動画を非公開にします](/handbook/marketing/marketing-operations/youtube/#make-private-quickly)。
+1. EM、PM、開発チームと連携し、脆弱性の修正を優先して取り組むよう促します。
+1. 脆弱性の重大度に応じて、Delivery、Dedicated、関連する開発チームと、アドホックな重要なセキュリティリリースのスケジューリングについて会話を始めることを検討します。
+
+#### フォローアップアクション
+
+1. 漏洩を引き起こしたチームメンバーに連絡し、[脆弱性関連データ](https://internal.gitlab.com/handbook/security/data_classification/#data-classification-index)の安全な取り扱いについて教育します。
+
+以下について:
+
+- 脆弱性 Issue が confidential として作成されなかった、または誤って全員に表示されるようになった
+- 修正がリリースに含まれていないにもかかわらず、誤ってセキュリティリリースのブログ記事に追加された
+
+#### コミュニケーションミスやその他の意図しない漏洩への即時対応
+
+1. Issue の confidentiality を変更します。
+1. ブログ記事を編集し、すぐにマージするようオンコールの SRE にメンションします。
+1. Slack で `/security` を使用して SIRT を呼び出します。
+
+#### コミュニケーションミスやその他の意図しない漏洩への緩和
+
+1. EM、PM、開発チームと連携し、脆弱性の修正を優先して取り組むよう促します。
+1. 脆弱性の重大度に応じて、Delivery、Dedicated、関連する開発チームと、アドホックな重要なセキュリティリリースのスケジューリングについて会話を始めることを検討します。
+
+#### コミュニケーションミスやその他の意図しない漏洩へのフォローアップアクション
+
+1. Issue の confidentiality がチームメンバーによって誤って変更されたか? もしそうなら、[脆弱性関連データ](https://internal.gitlab.com/handbook/security/data_classification/#data-classification-index)の安全な取り扱いについて教育します。
+1. リリースが公開される前にこのようなミスがないよう慎重に審査されるため、AppSec のリリースマネージャーにインシデントについてメンションします。
+1. ブログ記事への脆弱性詳細の追加は Delivery チームによって自動化されています。これがツール側のバグであるかどうかを判断するため、彼らに連絡します。

--- a/content/handbook/security/product-security/psirt/runbooks/unintended-vuln-disclosure.md
+++ b/content/handbook/security/product-security/psirt/runbooks/unintended-vuln-disclosure.md
@@ -1,6 +1,6 @@
 ---
 title: 意図しない脆弱性開示の取り扱い
-summary: 意図しない脆弱性開示の様々なシナリオに対応するためのランブック。
+summary: The runbook for handling different scenarios of unintended vulnerability disclosures.
 upstream_path: /handbook/security/product-security/psirt/runbooks/unintended-vuln-disclosure/
 upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
 translated_at: "2026-05-10T00:00:00Z"

--- a/content/handbook/security/product-security/psirt/runbooks/upstream-security-patches.md
+++ b/content/handbook/security/product-security/psirt/runbooks/upstream-security-patches.md
@@ -1,0 +1,10 @@
+---
+title: アップストリームのセキュリティパッチを取り扱う方法
+upstream_path: /handbook/security/product-security/psirt/runbooks/upstream-security-patches/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+{{% include-remote "https://gitlab.com/gitlab-org/release/docs/-/raw/master/runbooks/security/upstream_security_patches.md" 1 %}}

--- a/content/handbook/security/product-security/psirt/runbooks/verifying-security-fixes.md
+++ b/content/handbook/security/product-security/psirt/runbooks/verifying-security-fixes.md
@@ -1,0 +1,106 @@
+---
+title: "セキュリティ修正の検証"
+upstream_path: /handbook/security/product-security/psirt/runbooks/verifying-security-fixes/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+アプリケーションセキュリティエンジニアによる修正のレビューは、修正を実装するエンジニアによって発動されます。脆弱性報告をトリアージしたセキュリティエンジニアが、修正に関するマージリクエストの検証を担当します。検証作業を行うエンジニアとしては、以下の手順に従ってください。
+
+1. セキュリティの観点からコードレビューを実施します。
+1. `package-and-qa` で生成された Docker イメージを使用してセキュリティ修正を検証します。詳細は[以下のセクション](#validating-security-fixes-using-package-and-qa)を参照してください。
+1. 検証が完了したら、CVE へのリンクでセキュリティ Issue を更新します。
+
+   - リンクはセキュリティ実装 Issue の Summary > Links テーブルの `CVE ID request` ラベル付きセルの隣に配置します
+   - 修正が CVE を必要としない場合、その理由とともに CVE をリクエストしない旨をセキュリティ実装 Issue に投稿します
+   - HackerOne からのインポート時に CVE が作成された場合、提出内容に最新の詳細が含まれているかをダブルチェックします
+
+**注**: 承認は `master` を対象とするマージリクエストに対してのみ必要です。バージョン付きの安定版ブランチ (`X-Y-stable-ee`) を対象とするマージリクエストには必要ありません。
+**注**: 上記のプロセスは GitLab の修正を検証するためのものです。他のサブコンポーネント (Omnibus GitLab、Gitaly、GitLab Pages) の修正を検証するプロセスは異なる場合があります。
+
+## ローカル GDK を使用したセキュリティ修正の検証
+
+1. GitLab Security プロジェクト (`https://gitlab.com/gitlab-org/security/gitlab`) を使用して、[Install GDK using alternative projects](https://gitlab.com/gitlab-org/gitlab-development-kit/-/blob/main/doc/install_alternatives.md#install-gdk-using-alternative-projects) の手順に従って GDK をインストールし、問題なく動作していることを確認します。
+1. セキュリティ修正のあるマージリクエストに移動し、ブランチ名を特定します (ブランチ名は MR タイトルの下に表示されます。例: `User1` requested to merge `security-fix-branch` into `target-branch`)。
+1. ターミナルで `gitlab-development-kit/gitlab` フォルダに移動し、セキュリティ修正のあるブランチに切り替えて、コード変更を `gitlab` ディレクトリに取り込みます。
+1. まだ追加していない場合は、security リポジトリをリモートとして追加します:
+`git remote add security git@gitlab.com:gitlab-org/security/gitlab.git git fetch security`
+1. アクセスを確認します (origin と security の両方のリモートが表示されるはずです):
+`git remote -v`
+1. Security ブランチに切り替えます:
+     - 最新の security 変更を fetch する `git fetch security`
+     - 利用可能な security ブランチをリストする (オプション) `git branch -r | grep PATCH_BRANCH_NAME`
+     - 特定の MR ブランチをチェックアウトする `git checkout PATCH_BRANCH_NAME`
+1. `gdk restart` で GDK を再起動すると、GDK はセキュリティ修正が適用された状態で動作します。
+
+**注**: ブランチを切り替えると GDK の問題が発生する可能性があります。
+
+1. [GDK トラブルシューティングガイド](https://gitlab.com/gitlab-org/gitlab-development-kit/-/blob/main/doc/troubleshooting/_index.md)を参照してください。
+1. #gdk Slack チャンネルで支援を求めてください。
+
+## Gitpod を使用したセキュリティ修正の検証
+
+1. 新しい Gitpod インスタンスを起動します https://gitlab.com/gitlab-org/gitlab-development-kit/-/blob/main/doc/howto/gitpod.md
+1. Gitpod インスタンスが起動したら、MR の右上にある `Code` オプションをクリックして、セキュリティ MR からパッチをダウンロードします。
+1. Gitpod インスタンスのターミナルで: `cat > mr.patch <hit return> <paste contents> <hit control+d>` を実行します。次に、パッチを適用します: `git apply mr.patch`
+1. Gitpod 上で GDK を再起動します: `gdk restart`
+1. GitPod のウェブサーバーに到達できるようにします: Gitpod の Ports ペインでポート 3000 の行を見つけ、ロックアイコンをクリックしてポートを公開します。
+同じ Ports ペインの同じポート 3000 の行で、URL をクリックして GitLab インスタンスにアクセスします。
+
+## `package-and-qa` を使用したセキュリティ修正の検証 {#validating-security-fixes-using-package-and-qa}
+
+**注**: Delivery チームがこのプロセスをまとめた[動画](https://youtu.be/0IP3m48zWRg)を録画しました。AppSec チームメンバーは強く視聴することを推奨します。
+
+`package-and-qa` ビルドは、マージリクエストの変更から生成された Omnibus パッケージに対してエンドツーエンドテストを実行します。
+マージリクエストで導入されたセキュリティ修正が脆弱性を修復することを検証するため、Security エンジニアはこのパッケージを使用してローカル環境で Docker イメージを起動します。
+
+そのため、Security エンジニアは以下の手順に従う必要があります。
+
+1. セキュリティマージリクエストで、`qa` ステージをクリックし、`e2e:test-on-omnibus` ビルドを起動します。
+   - QA ステージの Docker ビルドが存在しない場合は、MR に `~"pipeline:run-all-e2e"` のラベルを付けて、Docker イメージを生成する QA ステージのパイプラインを開始します。必ず新しいパイプラインを開始してください。詳細は[このハンドブックページ](https://docs.gitlab.com/omnibus/build/team_member_docs.html#test-a-gitlab-orggitlab-project-merge-request)を参照してください。
+1. 内部的には、`e2e:test-on-omnibus` ビルドが [Omnibus GitLab Mirror] プロジェクトでパイプラインを起動します。
+1. [Omnibus GitLab Mirror](https://gitlab.com/gitlab-org/build/omnibus-gitlab-mirror/) のパイプラインで、`Docker-branch` ビルドが完了するまで待ちます。
+1. その間に、
+    - `registry.gitlab.com` にログインしていることを確認します。事前設定された Docker 認証情報、または [Personal Access Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) や [Deploy Token](https://docs.gitlab.com/ee/user/project/deploy_tokens/) を使用して、`docker login registry.gitlab.com` (使用しているものに応じて `nerdctl login registry.gitlab.com -u <username>`) コマンドでログインできます。
+    - Omnibus で [Set up volumes location](https://docs.gitlab.com/ee/install/docker/index.html#set-up-the-volumes-location) を完了します。
+1. `Docker-branch` が完了したら、ログの末尾までスクロールして、`registry.gitlab.com` にプッシュされた Docker イメージを見つけます。`Combined <AMD_64_TAG> and <ARM_64_TAG> tags to <FINAL_IMAGE>` の形式の行を探します。その `<FINAL_IMAGE>` が探しているものです。
+1. ローカル環境で Docker イメージを起動するには、[ドキュメント](https://docs.gitlab.com/ee/install/docker/index.html)に従い、`gitlab/gitlab-ee:latest` イメージを前のステップのものに置き換えます。
+1. インストールが完了するまで待ちます。その後、ブラウザで `0.0.0.0:80` にアクセスしてローカルインスタンスにアクセスできるようになります。
+
+## CVE のリクエスト
+
+1. [gitlab-org/cves](https://gitlab.com/gitlab-org/cves/-/issues) リポジトリの Issue トラッカーにアクセスします。このリポジトリのテンプレートを使用して Issue を作成し CVE をリクエストします。
+1. GitLab self-managed バージョンに影響するすべての脆弱性 (CVSSv3 スコア > 0) について、新しい Issue を作成し `Internal GitLab Submission` テンプレートを選択して CVE 識別子をリクエストします。セキュリティリリースに含まれる一部のマージリクエストには CVE 識別子は不要であることに注意してください (例: 第三者依存関係のアップグレードのみ、gitlab.com 限定の Issue など)。
+
+   - CVSSv3 スコアは Bug Bounty Council Issue で少なくとも 2 名のチームメンバーによって承認されているはずです。このプロセスより前の報告については、CVSSv3 スコアについて他のチームメンバーと議論するためだけであっても、現在の Council Issue にメモを追加することをためらわないでください。
+
+1. CVE 識別子がほぼ確実に必要となる場合は、'Automatically request a CVE ID' のボックスをチェックしてください。これにより、プロセスの最初に CVE 識別子がリクエストされることが保証されます。
+1. 各 Issue の `Title` には、ブログ記事のエントリに含まれる予定の脆弱性タイトルを使用してください。
+1. `reporter` セクションは、CVE のリクエスト者である私たちを指しており、脆弱性の報告者ではありません。これらのフィールドにはデフォルト値を使用してください。
+1. 残りのフィールドは、テンプレートまたは過去の提出物を例として参照しながら、関連情報で埋めてください。適切な `cwe` 値を調べる必要がある可能性が高い ([CWE](https://cwe.mitre.org/) 参照) ことと、`impact` を判定するために [CVSSv3 計算ツール](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator) を使用する必要があることに注意してください。
+1. 注: `fixed_versions` や `solution` などの一部の情報は、CVE リクエスト Issue が作成された時点ではすぐに利用可能でない場合があります。それらの情報を取得したら、必ず CVE Issue を更新してください。
+1. Issue を提出します。Vulnerability Research チームによってレビューされます。質問があればフォローアップし、その後、CVE 識別子を割り当てるために提出されます。
+1. 各 CVE リクエスト提出について、関連するセキュリティ Issue とリンクします。CVE 識別子が割り当てられたら、関連 Issue にもその旨をコメントし、ブログ記事に確実に含まれるようにしてください。
+
+### CVE クレジット
+
+ほとんどの脆弱性は HackerOne 研究者またはチームメンバーのいずれかにクレジットされます。これらの報告は常に既存の CVE テンプレートを使用してクレジットされます。
+
+脆弱性が GitLab Issue として直接、または ZenDesk 経由で顧客から報告された場合、公にクレジットされる機会を提供します。
+
+```text
+Hello `[contact]`,
+
+We are preparing to patch the issue you reported. Would you like to be publicly credited with discovering the issue, and if so, how?
+
+Some suggestions are `@social_media_handle`, `FirstName LastName`, `FirstName LastName from CustomerName`, or `the team at CustomerName`. We can also format the credit with a link.
+
+Our default credit will be `This vulnerability was reported by a customer` for customers and `This vulnerability was disclosed using our [Coordinated Disclosure Process](https://about.gitlab.com/security/disclosure/).` for other members of the wider GitLab community.
+```
+
+## CVE の更新
+
+CVE が公開された後に更新するには、<https://gitlab.com/gitlab-org/cves> でマージリクエストを開き、`published/CVE-YYYY-IDIDID.json` を変更します。
+レビューとマージのために `gitlab-org/secure/vulnerability-research` にメンションします。Vulnerability Research チームが MITRE および/または NVD で CVE を更新する処理を行います。

--- a/content/handbook/security/product-security/psirt/runbooks/working-with-sirt.md
+++ b/content/handbook/security/product-security/psirt/runbooks/working-with-sirt.md
@@ -1,0 +1,63 @@
+---
+title: "SIRT との連携"
+upstream_path: /handbook/security/product-security/psirt/runbooks/working-with-sirt/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+このランブックは、HackerOne 報告、発見された脆弱性、その他のセキュリティインシデントへの対応のために SIRT を巻き込んで作業する必要のある PSIRT エンジニア向けです。
+
+## /security を使用して SIRT を巻き込むための要件
+
+P1S1 の場合は、[P1S1 ランブック](/handbook/security/product-security/psirt/runbooks/handling-s1p1/)に従い、[セキュリティオンコールを巻き込みます](/handbook/security/security-operations/sirt/engaging-security-on-call/)。
+
+`/security` を使用して SIRT を巻き込む際:
+
+- 脆弱性を検証した後、またはインシデントが確認できた後にのみ `/security` を使用してください
+- フォームをできるだけ完全に記入してください
+- 関連する HackerOne 報告、GitLab Issue/MR、Slack メッセージへのリンク、これまでに発生した内容のサマリー、セキュリティリスクの説明を含めてください
+- 適切な緊急度を選択してください (以下のガイドラインを参照)
+- `/security` を使用すると、SIRT がインシデントの追跡と対応に使用する Tines ケースが開かれます
+- PSIRT は Tines ケースにアクセスして進捗を追跡し、追加の詳細・メモ・質問を追加できます
+
+## SIRT を巻き込む必要がある状況
+
+注: これは網羅的なリストではありません。SIRT を巻き込む必要のある他の状況がある可能性があります。
+
+- P1 脆弱性
+- 公に利用可能な悪用コードがある、公に知られた P2 脆弱性
+- シークレットの漏洩
+- アカウント乗っ取りに繋がる可能性のある脆弱性
+- 通常のプロセスに加えて顧客とのコミュニケーションが必要となる脆弱性
+- セキュリティリポジトリで行われるべきだったセキュリティ修正が公開で行われた場合
+- 個人情報の漏洩
+- DNS テイクオーバー
+
+## 緊急度ガイドライン
+
+`/security` フォームで緊急度を選択する際のガイドラインです。
+
+| インシデントの種類 | 緊急度 | 備考 |
+| --- | --- | --- |
+| 何らかの S1 | Urgent (即座にページ) | クリティカルな脆弱性、red データの公開、まだ有効なチームメンバーのトークン漏洩などが該当 |
+| 個人情報の漏洩 | Not Urgent (24 時間以内にレビュー) | 量とデータによっては Urgent になる可能性があります |
+| `security-fix-in-public` ラベルが付いていない、脆弱性を修正する公開マージリクエスト | 備考を参照 | S2 以上は Urgent の可能性が高く、S3 以下は Not Urgent |
+
+詳細については、[SIRT のインシデント分類および重大度マトリックス](/handbook/security/security-operations/sirt/severity-matrix/)ページの閲覧を検討してください。
+
+## /security を使用せずに SIRT の注意を引く
+
+何かが起こっている、またはまもなくインシデントになる可能性があることを、ただ SIRT に認識してもらいたい状況もあります。例としては、信頼できる HackerOne 報告者からの未検証で重大度の高い HackerOne 報告などが挙げられます。
+
+`#sd_security_operations` Slack チャンネルに状況の簡単な説明を含むメッセージを投稿してください。`/sirtoncall` を使用してオンコール担当者を判定し、メンションすることを検討してもよいでしょう。
+
+HackerOne 報告については、報告を GitLab Issue にインポートし、その上で `@gitlab-com/gl-security/security-operations/sirt` にメンションすることもできます。これは SIRT のすべてのチームメンバーにピンを送ることになるため、適切でない可能性があることに留意してください。
+
+## 一般的なインシデント支援
+
+- SIRT のブリッジに参加するか、SIRT と非同期で協力できる準備をしておきます
+- サマリーの作成、再現手順の文書化、Tines ケースのタイムライン/メモを最新に保つことを支援します
+- SIRT Tines ケースとディスカッションスレッドに情報とコンテキストを追加します
+- ログレビューを支援するため、アクセスタイムスタンプ、自分の IP アドレス、HackerOne 報告者 (および/または HackerOne トリアージチーム) の IP アドレスで Tines ケースを更新します

--- a/translation-state/manifest.json
+++ b/translation-state/manifest.json
@@ -21025,6 +21025,76 @@
       "translated_at": "2026-05-10T00:00:00Z",
       "model": "claude-opus-4-7[1m]",
       "input_hash": "52a5eeb901effe61fbc0c9ae0be8489f13db61a40635aef718da7e12328556fa"
+    },
+    "content/handbook/security/product-security/psirt/runbooks/cvss-calculation.md": {
+      "path": "content/handbook/security/product-security/psirt/runbooks/cvss-calculation.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7[1m]",
+      "input_hash": "4fabe88cd9b397dad7df236bb9355fcc5624d3102d24b2362e0c156455f17d6f"
+    },
+    "content/handbook/security/product-security/psirt/runbooks/hackerone-process.md": {
+      "path": "content/handbook/security/product-security/psirt/runbooks/hackerone-process.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7[1m]",
+      "input_hash": "c49b757c10b7fd4da07205819ca7da08c38f28827e7b1e111e10b405c1ff46a6"
+    },
+    "content/handbook/security/product-security/psirt/runbooks/handling-s1p1.md": {
+      "path": "content/handbook/security/product-security/psirt/runbooks/handling-s1p1.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7[1m]",
+      "input_hash": "25401cd61e3444756f5b086e8a69f0ff082deca1f1bd95e803ac8c051a6ead9c"
+    },
+    "content/handbook/security/product-security/psirt/runbooks/holiday-coverage.md": {
+      "path": "content/handbook/security/product-security/psirt/runbooks/holiday-coverage.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7[1m]",
+      "input_hash": "9f5bfabb2b17e0250abf8d04c9b228af0bbde3bc9831ec32dc766f3a3b069848"
+    },
+    "content/handbook/security/product-security/psirt/runbooks/psirt-case-lifecycle.md": {
+      "path": "content/handbook/security/product-security/psirt/runbooks/psirt-case-lifecycle.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7[1m]",
+      "input_hash": "f4616b64fcdba51ba0f6b57bb8ee241299e17ccd03999605857ff6e2509fb2fa"
+    },
+    "content/handbook/security/product-security/psirt/runbooks/security-engineer.md": {
+      "path": "content/handbook/security/product-security/psirt/runbooks/security-engineer.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7[1m]",
+      "input_hash": "029e2b1a2392b0a2d5325722a48f700224a0e1fb97fe2f17cf9f6dc6d20da06b"
+    },
+    "content/handbook/security/product-security/psirt/runbooks/unintended-vuln-disclosure.md": {
+      "path": "content/handbook/security/product-security/psirt/runbooks/unintended-vuln-disclosure.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7[1m]",
+      "input_hash": "cb482ae24b6e6af5aeac772e219a9805acc23429e20d603ebdcd8d7d03451cbd"
+    },
+    "content/handbook/security/product-security/psirt/runbooks/upstream-security-patches.md": {
+      "path": "content/handbook/security/product-security/psirt/runbooks/upstream-security-patches.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7[1m]",
+      "input_hash": "10d13551501d5ca2963aa00d1f9f52cda8e941e3ab1423b4e373d12171f0d7e6"
+    },
+    "content/handbook/security/product-security/psirt/runbooks/verifying-security-fixes.md": {
+      "path": "content/handbook/security/product-security/psirt/runbooks/verifying-security-fixes.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7[1m]",
+      "input_hash": "68d4090bd4c1e359c248b98779e1163e60c361e32ae6175c7428cb82de0b4851"
+    },
+    "content/handbook/security/product-security/psirt/runbooks/working-with-sirt.md": {
+      "path": "content/handbook/security/product-security/psirt/runbooks/working-with-sirt.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7[1m]",
+      "input_hash": "fb028639ee314b36b55c662dd7dc4b66cad88699485f3e8c3c7f07c211b75039"
     }
   }
 }


### PR DESCRIPTION
## Summary
- 10 ファイルを翻訳・追加（PSIRT runbooks セクション）
- upstream SHA: \`1e195b58b9f249ff10bd0e705106c320fee86141\`
- translator サブエージェント (\`.claude/agents/translator.md\`) で生成、\`translation-state/manifest.json\` を更新済み（3185 → 3195）
- このPRは #171 を base にしているので、先行PRが順にマージされたら自動で main に rebase されます

## 翻訳ファイル
- \`content/handbook/security/product-security/psirt/runbooks/cvss-calculation.md\`
- \`content/handbook/security/product-security/psirt/runbooks/hackerone-process.md\`
- \`content/handbook/security/product-security/psirt/runbooks/handling-s1p1.md\`
- \`content/handbook/security/product-security/psirt/runbooks/holiday-coverage.md\`
- \`content/handbook/security/product-security/psirt/runbooks/psirt-case-lifecycle.md\`
- \`content/handbook/security/product-security/psirt/runbooks/security-engineer.md\`
- \`content/handbook/security/product-security/psirt/runbooks/unintended-vuln-disclosure.md\`
- \`content/handbook/security/product-security/psirt/runbooks/upstream-security-patches.md\`
- \`content/handbook/security/product-security/psirt/runbooks/verifying-security-fixes.md\`
- \`content/handbook/security/product-security/psirt/runbooks/working-with-sirt.md\`

## 注記
- 内部リンク参照アンカー ID（hackerone-process.md の各見出し等）を多数明示付与
- handover メッセージテンプレートと CVE クレジット用英文は原文のまま保持

## Test plan
- [x] \`hugo --renderToMemory\` クリーン（キャッシュ削除後）、エラー 0 件、3241 ページ
- [ ] CodeRabbit レビュー対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * PSIRT 向け日本語ランブックを一式追加：CVSS 判定、HackerOne プロセス、優先度1緊急対応、休暇時カバレッジ、ケースライフサイクル、SIRT 連携、意図しない脆弱性開示対応、アップストリームパッチ対応、セキュリティ修正の検証、セキュリティエンジニア向け参照化。
  * 翻訳追跡情報（manifest）を更新しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyama0/gitlab-handbook-ja/pull/173)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->