### PR TITLE
translation: batch 2026-05-10-29 (security gitlab self/ops/dev/demo/com)

### DIFF
--- a/content/handbook/security/corporate/systems/gitlab/com/_index.md
+++ b/content/handbook/security/corporate/systems/gitlab/com/_index.md
@@ -1,0 +1,10 @@
+---
+title: 社内チームメンバーおよび臨時サービスプロバイダー向け GitLab.com SaaS
+upstream_path: /handbook/security/corporate/systems/gitlab/com/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T12:00:00Z"
+translator: claude
+stale: false
+---
+
+これはプレースホルダーページです。存在する子ページについては、以下のリンクを参照してください。

--- a/content/handbook/security/corporate/systems/gitlab/com/licenses/_index.md
+++ b/content/handbook/security/corporate/systems/gitlab/com/licenses/_index.md
@@ -1,0 +1,10 @@
+---
+title: チームメンバーおよび臨時サービスプロバイダー向け GitLab.com SaaS 内部ライセンス
+upstream_path: /handbook/security/corporate/systems/gitlab/com/licenses/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T12:00:00Z"
+translator: claude
+stale: false
+---
+
+これはプレースホルダーページです。存在する子ページについては、以下のリンクを参照してください。

--- a/content/handbook/security/corporate/systems/gitlab/com/namespaces/_index.md
+++ b/content/handbook/security/corporate/systems/gitlab/com/namespaces/_index.md
@@ -1,0 +1,10 @@
+---
+title: 社内利用ケース向け GitLab.com SaaS トップレベル名前空間グループ
+upstream_path: /handbook/security/corporate/systems/gitlab/com/namespaces/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T12:00:00Z"
+translator: claude
+stale: false
+---
+
+これはプレースホルダーページです。存在する子ページについては、以下のリンクを参照してください。

--- a/content/handbook/security/corporate/systems/gitlab/com/projects/_index.md
+++ b/content/handbook/security/corporate/systems/gitlab/com/projects/_index.md
@@ -1,0 +1,10 @@
+---
+title: チームメンバーおよび臨時サービスプロバイダー向け GitLab.com SaaS プロジェクト
+upstream_path: /handbook/security/corporate/systems/gitlab/com/projects/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T12:00:00Z"
+translator: claude
+stale: false
+---
+
+これはプレースホルダーページです。存在する子ページについては、以下のリンクを参照してください。

--- a/content/handbook/security/corporate/systems/gitlab/com/setup/_index.md
+++ b/content/handbook/security/corporate/systems/gitlab/com/setup/_index.md
@@ -1,0 +1,10 @@
+---
+title: チームメンバーおよび臨時サービスプロバイダー向け GitLab.com SaaS ユーザーセットアップ
+upstream_path: /handbook/security/corporate/systems/gitlab/com/setup/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T12:00:00Z"
+translator: claude
+stale: false
+---
+
+これはプレースホルダーページです。存在する子ページについては、以下のリンクを参照してください。

--- a/content/handbook/security/corporate/systems/gitlab/demo/_index.md
+++ b/content/handbook/security/corporate/systems/gitlab/demo/_index.md
@@ -1,0 +1,10 @@
+---
+title: GitLab セールスデモインスタンス (cs.gitlabdemo.cloud)
+upstream_path: /handbook/security/corporate/systems/gitlab/demo/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T12:00:00Z"
+translator: claude
+stale: false
+---
+
+これはプレースホルダーページです。存在する子ページについては、以下のリンクを参照してください。

--- a/content/handbook/security/corporate/systems/gitlab/dev/_index.md
+++ b/content/handbook/security/corporate/systems/gitlab/dev/_index.md
@@ -1,0 +1,10 @@
+---
+title: GitLab 製品開発インスタンス (dev.gitlab.org)
+upstream_path: /handbook/security/corporate/systems/gitlab/dev/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T12:00:00Z"
+translator: claude
+stale: false
+---
+
+これはプレースホルダーページです。存在する子ページについては、以下のリンクを参照してください。

--- a/content/handbook/security/corporate/systems/gitlab/ops/_index.md
+++ b/content/handbook/security/corporate/systems/gitlab/ops/_index.md
@@ -1,0 +1,10 @@
+---
+title: 製品本番環境 GitOps 構成管理 (ops.gitlab.net)
+upstream_path: /handbook/security/corporate/systems/gitlab/ops/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T12:00:00Z"
+translator: claude
+stale: false
+---
+
+これはプレースホルダーページです。存在する子ページについては、以下のリンクを参照してください。

--- a/content/handbook/security/corporate/systems/gitlab/self/_index.md
+++ b/content/handbook/security/corporate/systems/gitlab/self/_index.md
@@ -1,0 +1,10 @@
+---
+title: チームメンバー向け GitLab セルフマネージドデプロイメント
+upstream_path: /handbook/security/corporate/systems/gitlab/self/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T12:00:00Z"
+translator: claude
+stale: false
+---
+
+これはプレースホルダーページです。存在する子ページについては、以下のリンクを参照してください。

--- a/content/handbook/security/corporate/systems/gitlab/self/licenses/_index.md
+++ b/content/handbook/security/corporate/systems/gitlab/self/licenses/_index.md
@@ -1,0 +1,10 @@
+---
+title: チームメンバー向け GitLab セルフマネージド内部ライセンス
+upstream_path: /handbook/security/corporate/systems/gitlab/self/licenses/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T12:00:00Z"
+translator: claude
+stale: false
+---
+
+GitLab チームメンバー専用のセルフマネージドライセンスをリクエストするには、この[フォーム](https://support-super-form-gitlab-com-support-support-op-651f22e90ce6d7.gitlab.io/)を使用し、ドロップダウンで `Request a team member license` を選択してください。

--- a/translation-state/manifest.json
+++ b/translation-state/manifest.json
@@ -20675,6 +20675,76 @@
       "translated_at": "2026-05-09T12:00:00Z",
       "model": "claude-opus-4-7",
       "input_hash": "ba8d6e76e01df3205f462081cfbb820cecbdd32535dac0dd3ae07ba3ccf73484"
+    },
+    "content/handbook/security/corporate/systems/gitlab/self/_index.md": {
+      "path": "content/handbook/security/corporate/systems/gitlab/self/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T12:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "42f1c3f322343d500baa6a7fbe86f629f18c75a7c8dff6403f5151ebbf62aa7e"
+    },
+    "content/handbook/security/corporate/systems/gitlab/self/licenses/_index.md": {
+      "path": "content/handbook/security/corporate/systems/gitlab/self/licenses/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T12:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "6c5dd8332a9a2010a0a80933a3179b64607900469888b052ad79ab8969ec6e99"
+    },
+    "content/handbook/security/corporate/systems/gitlab/ops/_index.md": {
+      "path": "content/handbook/security/corporate/systems/gitlab/ops/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T12:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "2943e3abc4a5e4aa391c4f2a309c32b8bbb50093d6a5fd27f58fcfb9e63c2b23"
+    },
+    "content/handbook/security/corporate/systems/gitlab/dev/_index.md": {
+      "path": "content/handbook/security/corporate/systems/gitlab/dev/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T12:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "6ef7ee2eacca0805fea2f552173204116cc6df9a7279c69309ecd8d3f2324d56"
+    },
+    "content/handbook/security/corporate/systems/gitlab/demo/_index.md": {
+      "path": "content/handbook/security/corporate/systems/gitlab/demo/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T12:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "c6d28400cee564543cbe4f76a2286e536129dfeb44cb5292a2accbedc7befe2d"
+    },
+    "content/handbook/security/corporate/systems/gitlab/com/_index.md": {
+      "path": "content/handbook/security/corporate/systems/gitlab/com/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T12:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "6dd242f76d7f7ae7b365e7529ec32de0b06c9f0b50e6c612f6d8c32ac4337669"
+    },
+    "content/handbook/security/corporate/systems/gitlab/com/setup/_index.md": {
+      "path": "content/handbook/security/corporate/systems/gitlab/com/setup/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T12:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "52cca6a1ef7919508eef6f074d032c85150eec33ec59ef50cc1b5ffe0de08eea"
+    },
+    "content/handbook/security/corporate/systems/gitlab/com/projects/_index.md": {
+      "path": "content/handbook/security/corporate/systems/gitlab/com/projects/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T12:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "9ae301fdb10ea938e185ab1ea4e7dfa93fc369ab1c6f0c9094f58df552b4ec48"
+    },
+    "content/handbook/security/corporate/systems/gitlab/com/namespaces/_index.md": {
+      "path": "content/handbook/security/corporate/systems/gitlab/com/namespaces/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T12:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "e984004c51669d64f4f6d823721dc159eb004bcab2a2cdcf5f95f16aaf01ab92"
+    },
+    "content/handbook/security/corporate/systems/gitlab/com/licenses/_index.md": {
+      "path": "content/handbook/security/corporate/systems/gitlab/com/licenses/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T12:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "0fdfc4789ebff5abccf89306285c2af7f655508e0ad84894c54b70ccd9ae548f"
     }
   }
 }


### PR DESCRIPTION
## Summary
- 10 ファイルを翻訳して追加 (`content/handbook/security/corporate/systems/gitlab/` 配下: self, self/licenses, ops, dev, demo, com, com/setup, com/projects, com/namespaces, com/licenses)
- `translation-state/manifest.json` に 10 entries 追加 (3135 → 3145)
- base = `translation/batch-2026-05-10-28`

## Note
今回 `npm run sync:upstream` で報告される `[new]` の中には実は既訳済みファイル (manifest 抜けのみ) が混在しているため、`test -f` で実在しないファイルだけを対象にしています。

## Test plan
- [x] ローカルで `hugo --renderToMemory --quiet` がエラーなく完了
- [x] フロントマター追跡フィールド付与確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション

* GitLab.com SaaS、セルフマネージド、デモ、開発環境など、複数のGitLabデプロイメント向けのハンドブックページを新規追加しました。
* セットアップ、ライセンス管理、プロジェクト、ネームスペース設定に関する関連リソースへのアクセスポイントを統合しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyama0/gitlab-handbook-ja/pull/203)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->