### PR TITLE
translation: batch 2026-05-10-32 (corporate aws billing + accessctl/chk + 1password + support)

### DIFF
--- a/content/handbook/security/corporate/support/_index.md
+++ b/content/handbook/security/corporate/support/_index.md
@@ -1,0 +1,145 @@
+---
+title: 'コーポレートセキュリティ (CorpSec) サポート'
+upstream_path: /handbook/security/corporate/support/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+GitLab はオーガニックに成長してきた中で、いくつかの部門・職能グループは、自分たち固有のテックスタックアプリケーションの日常的な管理を担う独自のシステム管理者（「Tech Stack App/System Owners」）を持っています。これは、組織全体のコンプライアンス、インフラ、セキュリティのベストプラクティスという枠組みの中で運用されています。GitLab における各[テックスタックアプリケーション](/handbook/business-technology/tech-stack-applications/)には、その実装と、（部門または職能グループ内で）アプリケーションを利用するチームメンバーへの日常的な運用サポートを担う DRI としてのシステムオーナーが存在します。これは、従来型の IT 部門がボトルネックになるのを防ぎ、GitLab の[適切なグループにとっての効率性](/handbook/values/#efficiency-for-the-right-group)というサブバリューの一環として、各部門がセルフサービスを行えるようにするという副次的なメリットもあります。
+
+コーポレートセキュリティチームは、チームメンバーおよび一時的なサービスプロバイダー（コントラクター、ベンダーなど）向けの技術サポートヘルプデスクサービスと、私たちが管理する全社的な[システム](/handbook/security/corporate/systems)の構成管理エンジニアリングを提供しています。
+
+## コーポレートセキュリティサポート
+
+### Tier 1. セルフサービス
+
+[セルフサービスとセルフラーニング](/handbook/values/#self-service-and-self-learning)という効率性バリューの一環として、まずは[セキュリティのセルフサービスガイドおよびシステムドキュメント](/handbook/security/corporate/systems)を確認し、ご質問への回答を見つけられるかどうかを試してみることをお勧めします。
+
+探している情報が見つからない場合は、`#it_help` でお尋ねください。
+
+#### 将来の状態
+
+- (社内) Why: [方向性と戦略](https://internal.gitlab.com/handbook/security/corporate/direction)
+- (社内) What: [イニシアチブとプロジェクト](https://internal.gitlab.com/handbook/security/corporate/projects)
+- (社内) When: [OKR とロードマップ](https://internal.gitlab.com/handbook/security/corporate/roadmap)
+- (社内) How: [CorpSec Issue トラッカー](https://gitlab.com/gitlab-com/gl-security/corp/issue-tracker/-/issues)
+- (公開) Who: [チームの機能](/handbook/security/corporate/#team-functions)と[チームディレクトリ](/handbook/security/corporate/#team-directory)
+
+#### 現在の状態
+
+- [チームディレクトリ](/handbook/security/corporate/#team-directory)
+- **👀 新しいチームメンバー:** [IT オンボーディング 101 ガイド](/handbook/security/corporate/end-user-services/onboarding101/)
+- **👀 既存のチームメンバー:** [コーポレートセキュリティのシステムドキュメント、アクセスリクエスト、セルフサービスガイド](/handbook/security/corporate/systems)
+- **👷 管理者向けドキュメント:** (社内) [Systems Handbook（構成と Runbook）](https://handbook.gitlab.systems)
+- 👷 [エンジニアリング](/handbook/security/corporate/engineering)
+  - [デバイストラストエンジニアリング](/handbook/security/corporate/engineering/device-trust)
+  - [アイデンティティエンジニアリング](/handbook/security/corporate/engineering/identity)
+  - [インフラストラクチャエンジニアリング](/handbook/security/corporate/engineering/infrastructure)
+  - [プラットフォームエンジニアリング（セルフサービスツールのソフトウェア開発）](/handbook/security/corporate/engineering/platform)
+  - [SaaS エンジニアリング（コーポレートテックスタックアプリケーションとプラットフォーム）](/handbook/security/corporate/saas/)
+- 💻 [サービス](/handbook/security/corporate/services)
+  - [アクセスリクエスト](/handbook/security/corporate/services/access-requests)
+    - **アクセスが必要ですか？** 各システムごとの手順については、[システム](/handbook/security/corporate/sysetms)ページを参照してください。
+    - [外部コラボレーター（監査人、顧客、パートナー、ベンダー）](/handbook/security/corporate/services/external-collaborators)
+    - [インフラストラクチャプロビジョニング（AWS、Azure、GCP、Sandbox Cloud）](/handbook/security/corporate/services/infrastructure)
+    - [Okta アプリケーション](/handbook/security/corporate/systems/okta/ar)
+    - [サービスアカウント](/handbook/security/corporate/services/service-accounts)
+    - [一時的なサービスプロバイダー（コントラクターユーザー）](/handbook/security/corporate/services/temporary-users)
+  - [変更管理](/handbook/security/corporate/services/change-management)
+  - [メール](/handbook/security/corporate/services/email)
+  - デバイス管理
+    - [携帯電話とモバイルデバイス](/handbook/security/corporate/services/phones)
+    - [ノートパソコン](/handbook/security/corporate/end-user-services/laptop-management)
+      - **新しいノートパソコン**
+        - 👀 [オンボーディング時のハードウェア発注ガイド](/handbook/security/corporate/end-user-services/laptop-management/laptop-ordering/)
+        - 👀 [オンボーディング時のノートパソコンセットアップガイド](/handbook/security/corporate/end-user-services/onboarding101/)
+        - 👀 [Apple macOS セットアップガイド](/handbook/security/corporate/systems/macos/setup/)
+        - [Linux セットアップガイド](/handbook/security/corporate/systems/linux)
+      - **ノートパソコンの交換と修理**
+        - [リフレッシュ／交換ガイド](/handbook/security/corporate/end-user-services/laptop-management/laptop-ordering/#laptop-refreshes)
+        - [修理ガイド](/handbook/security/corporate/end-user-services/laptop-management/)
+      - **古いノートパソコン**
+        - [ワイプ（ファクトリーリセット）ガイド](/handbook/security/corporate/end-user-services/laptop-management/laptop-wipe/)
+        - [買い取りガイド](/handbook/security/corporate/end-user-services/laptop-management/laptop-offboarding-returns/#laptop-buybacks)
+        - [寄付ガイド](/handbook/security/corporate/end-user-services/laptop-management/laptop-offboarding-returns/#laptop-donations)
+        - [リサイクル／返却ガイド](/handbook/security/corporate/end-user-services/laptop-management/laptop-offboarding-returns/#laptop-returns)
+      - **ノートパソコンに関するポリシー**
+        - [調達ガイドと配送期間](/handbook/security/corporate/end-user-services/laptop-management/laptop-ordering)
+        - [ハードウェアモデルと仕様](/handbook/security/corporate/end-user-services/laptop-management/#laptop-specs)
+        - [オペレーティングシステム標準](/handbook/security/corporate/end-user-services/laptop-management)
+        - [アプリとソフトウェアの標準](/handbook/security/corporate/end-user-services/laptop-management/laptop-security/)
+        - [セキュリティ構成標準](/handbook/security/corporate/end-user-services/laptop-management/laptop-security)
+          - [業務用 Apple ID](/handbook/security/corporate/end-user-services/laptop-management/laptop-security/appleid)
+          - [バックアップ](/handbook/security/corporate/end-user-services/laptop-management/laptop-security/backups)
+          - [ディスク暗号化](/handbook/security/corporate/end-user-services/laptop-management/laptop-security/encryption)
+          - [ファイアウォール](/handbook/security/corporate/end-user-services/laptop-management/laptop-security/firewall)
+          - [ホスト名とユーザー名（社内）](https://internal.gitlab.com/handbook/security/corporate/tooling/jamf/endpoint_naming_convention/)
+          - [iCloud Drive](/handbook/security/corporate/end-user-services/laptop-management/laptop-security/icloud)
+          - [離席時のロック](/handbook/security/corporate/end-user-services/laptop-management/laptop-security/unattended)
+          - [パスワード管理](/handbook/security/corporate/end-user-services/laptop-management/laptop-security/passwords)
+          - [個人利用](/handbook/security/corporate/end-user-services/laptop-management/laptop-security/personal/)
+          - [リモート管理（MDM および EDR）](/handbook/security/corporate/end-user-services/laptop-management/laptop-security/management)
+          - [ソフトウェアアップデート](/handbook/security/corporate/end-user-services/laptop-management/laptop-security/updates/)
+          - [Touch ID（生体認証パスワードと 2FA）](/handbook/security/corporate/end-user-services/laptop-management/laptop-security/touchid/)
+          - [Web ブラウザ](/handbook/security/corporate/end-user-services/laptop-management/laptop-security/browsers/)
+          - [ワイヤレスネットワークと VPN](/handbook/security/corporate/end-user-services/laptop-management/laptop-security/networks)
+- 雇用ライフサイクル
+  - [オンボーディング](/handbook/security/corporate/services/onboarding)
+  - [ロール変更（キャリアモビリティ）](/handbook/security/corporate/services/role-changes)
+  - [オフボーディング](/handbook/security/corporate/services/offboarding)
+- [ヘルプデスクサポート](/handbook/security/corporate/services/helpdesk)
+  - サポートを受けるには、[Support](/handbook/security/corporate/support) または [Systems](/handbook/security/corporate/systems) のページを参照してください。
+  - 探している答えが見つからない場合は、下にスクロールして Tier 2 サポートをご覧ください。
+
+### Tier 2. ヘルプデスクサポート
+
+私たちは、24x5 のカバレッジを[ヘルプデスクサポートアナリスト](/handbook/security/corporate/services/helpdesk)が提供しています。アクセスリクエスト、アカウントロックアウト、認証関連の問題、ノートパソコンのハードウェア、ノートパソコンのソフトウェア構成の問題、慣れていないテクノロジーに関する 1:1 のトレーニング、そして[コーポレートセキュリティシステム](/handbook/security/corporate/systems)に関連する問題のトリアージを支援しています。
+
+- [アイデンティティとアクセス管理](/handbook/security/corporate/services/identity)
+  - [アクセスリクエスト](/handbook/security/corporate/services/access-requests)
+  - [キャリアモビリティ（Mover）とロール変更時のプロビジョニング](/handbook/security/corporate/services/role-changes)
+  - [外部コラボレーター（顧客、パートナー、ベンダー）](/handbook/security/corporate/services/external-collaborators)
+  - [オンボーディング（Joiner）プロビジョニング（ベースライン権限）とユーザーサポート](/handbook/security/corporate/services/onboarding)
+  - [オフボーディング（Leaver）デプロビジョニング](/handbook/security/corporate/services/offboarding)
+  - [サービスアカウント](/handbook/security/corporate/services/service-accounts)
+  - [一時的なサービスプロバイダー](/handbook/security/corporate/services/temporary-users/)
+- [インフラストラクチャ管理](/handbook/security/corporate/services/infrastructure)
+  - [AWS](/handbook/security/corporate/systems/aws)
+  - [GCP](/handbook/security/corporate/systems/google/cloud/)
+- [ノートパソコンとロジスティクス](/handbook/security/corporate/end-user-services/laptop-management)
+- [チームメンバー向けの技術サポート](/handbook/security/corporate/services/helpdesk/)
+  - [アカウントパスワードと 2FA のリセット](/handbook/security/corporate/support/reset)
+
+**支援が必要な場合は `#it_help` Slack チャンネルで質問してください。**
+
+私たちのチームメンバーはオンコールシフトをスケジュールに沿って担当しているため、特定の個人に Slack のダイレクトメッセージを送るのではなく、チャンネルで質問していただくようお願いしています。
+
+コーポレートセキュリティが管理していないシステムについては、[テックスタック](https://gitlab.com/gitlab-com/www-gitlab-com/-/blob/master/data/tech_stack.yml)でオーナーを確認できます。どこに尋ねればよいか分からない場合は、`#it_help` でお尋ねいただければ、適切な担当者や場所にご案内します。
+
+### Tier 3. エスカレーションとシステムエンジニアリング
+
+私たちのサポートアナリストは、ユーザーサポートを提供するためのトレーニングを受けています。サポートアナリストが回答できない問題があった場合には、コーポレートセキュリティエンジニアにエスカレーションされます。
+
+私たちのセキュリティエンジニアおよびシステムエンジニアは、[コーポレートセキュリティシステム](/handbook/security/corporate/systems)の技術的なオーナーであり、ビジネス要件の最適化・サポートとセキュリティリスクの軽減のための構成管理およびエンジニアリング業務を担っています。
+
+チームメンバーのサポートリクエストについては、`#it_help` Slack チャンネルで支援を求めてください。
+
+高度なリクエストや変更管理／構成管理については、[コーポレートセキュリティ Issue トラッカー](https://gitlab.com/gitlab-com/gl-security/corp/issue-tracker/-/issues)で GitLab Issue を作成し、適切な Issue テンプレートを選択してください。テンプレートを選ぶと、適切なラベルが自動的に追加され、該当するシステムオーナーにアサインされます。
+
+**ご注意:** 私たちはエンジニアリング Issue について **当日対応はしていません**。私たちの Issue には優先度付きのキューがあり、エンジニアリングマネージャーとプログラムマネージャーが管理しています。各チームには、新しい日々のリクエストを数営業日以内にトリアージできるようにバッファを確保しています。作成する Issue には、適切な優先度ラベルを付けてください。**緊急の対応が必要なものについては `#it_help` Slack チャンネルで質問してください**。エスカレーションと優先度付けは社内で対応します。
+
+### Tier 4. 自動化エンジニアリング
+
+どんな企業やチームも、進化と拡大に伴い、プロセスの自動化と効率化が重要になります。多くのテック企業は、何らかのスクリプトを用いて自動化とプロセスを改善しています。
+
+GitLab では、各部門が独立して自分たちの自動化の課題を解決しています（私たちのバリューと、自身のニッチな問題を解決するというあり方が、オーガニックに進化した結果です）。
+
+時間が許す限り、私たちのセキュリティエンジニアおよびシステムエンジニアは、プロセスとシステム構成を効率化するための自動化プロジェクトに取り組んでいます。これらは通常、私たちのセキュリティ戦略、コンプライアンス上の所見、特定されたセキュリティリスクの軽減と整合させて進めています。
+
+詳しくは、[自動化に関するハンドブックページ](/handbook/security/corporate/automation)をご覧ください。
+
+### Tier 5. アーキテクチャと危機管理
+
+私たちのスタッフエンジニアおよびマネージャーは、コーポレートセキュリティチームと、強固なセキュリティ態勢を提供しつつ優れた社内顧客体験を実現するための部門横断のステークホルダーに対し、メタレベルの方向性、自動化、効率性の向上を推進することに注力しています。これらはすべて、セキュリティのビジョンと整合する形で行われています。また、部門横断またはリーダーシップレベルの危機・インシデントの軽減に対して、スウォームスタイルのガイダンスとエンジニアリングも提供しています。

--- a/content/handbook/security/corporate/support/usb-encryption/_index.md
+++ b/content/handbook/security/corporate/support/usb-encryption/_index.md
@@ -1,0 +1,240 @@
+---
+title: コーポレートセキュリティ USB デバイス暗号化ガイド
+upstream_path: /handbook/security/corporate/support/usb-encryption/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+macOS または Linux で USB マスストレージデバイスを暗号化する方法を説明します。
+
+## macOS での手順
+
+### 前提条件
+
+- 暗号化したい USB ドライブ
+
+- macOS 10.13（High Sierra）以降
+
+- Mac の管理者権限
+
+### Disk Utility を使って USB ドライブを暗号化する手順
+
+1. USB ドライブを Mac の利用可能な USB ポートに挿入します。
+
+2. Disk Utility を開きます。
+
+   - Applications > Utilities > Disk Utility に移動するか、
+
+   - Spotlight で「Disk Utility」を検索します（Cmd + Space を押して「Disk Utility」と入力）
+
+3. 左側のサイドバーから USB ドライブを選択します。その下にあるボリュームではなく、ドライブそのもの（最上位のエントリ）を選択するようにしてください。
+
+4. ドライブを消去してフォーマットします。
+
+   - 上部ツールバーの「消去」ボタンをクリックします
+
+   - ドライブの名前を入力します
+
+   - 「フォーマット」では、「APFS（暗号化）」または「Mac OS 拡張（ジャーナリング、暗号化）」を選択します
+
+   - 「方式」では、「GUID パーティションマップ」を選択します
+
+   - 「消去」をクリックします
+
+5. パスワードを作成します。
+
+   - 暗号化されたドライブ用のパスワードを作成するよう求められます
+
+   - 強力なパスワードを入力し、確認します
+
+   - 必要に応じて、パスワードのヒントを入力します（推奨）
+
+   - 「選択」をクリックします
+
+   > **重要**: このパスワードは安全に保管してください。忘れてしまうと、ドライブのデータを復元することはできません。
+
+6. 処理が完了するまで待ち、「完了」をクリックします。
+
+これで USB ドライブが暗号化されました。Mac に接続するたびに、内容にアクセスするためのパスワードの入力を求められます。
+
+### 代替方法: ターミナルから FileVault を使う
+
+ターミナルを使う方が好ましい場合は、FileVault を使って USB ドライブを暗号化することもできます。
+
+```bash
+# まずディスク識別子を確認します
+diskutil list
+
+# 次にドライブを暗号化します（"disk2" は実際のディスク識別子に置き換えてください）
+diskutil cs convert disk2 -passphrase
+
+# プロンプトに従ってパスワードを作成します
+```
+
+### macOS 公式ドキュメント
+
+[Apple サポート: ストレージデバイスをパスワードで暗号化して保護する](https://support.apple.com/guide/disk-utility/encrypt-protect-a-storage-device-password-dskutl35612/mac)
+
+[Apple サポート: FileVault で Mac のデータを保護する](https://support.apple.com/guide/mac-help/protect-data-on-your-mac-with-filevault-mh11785/mac)
+
+[Apple サポート: Disk Utility の概要](https://support.apple.com/guide/disk-utility/welcome/mac)
+
+## Linux での手順
+
+### 前提条件
+
+- 暗号化を行うと USB 上のすべてのデータが消去されるため、既存のデータがバックアップ済みであること
+
+- 暗号化したい USB ドライブ
+
+- LUKS（Linux Unified Key Setup）をサポートする Linux ディストリビューション（最近のディストリビューションのほとんど）
+
+- `cryptsetup` パッケージがインストールされていること
+
+- root または sudo 権限
+
+### 必要なパッケージのインストール
+
+Debian/Ubuntu 系ディストリビューションの場合:
+
+```bash
+sudo apt update
+sudo apt install cryptsetup
+```
+
+Fedora/RHEL 系ディストリビューションの場合:
+
+```bash
+sudo dnf install cryptsetup
+```
+
+Arch 系ディストリビューションの場合:
+
+```bash
+sudo pacman -S cryptsetup
+```
+
+### LUKS を使って USB ドライブを暗号化する手順
+
+1. USB ドライブを Linux マシンの利用可能な USB ポートに挿入します。
+
+2. USB ドライブのデバイスパスを特定します。
+
+   ```bash
+   lsblk
+   ```
+
+   > 出力の中から USB ドライブを探します（例: `/dev/sdb`）。以下の手順ではドライブ上のすべてのデータが消去されるため、必ず正しいデバイスを特定してください。
+
+3. 新しいパーティションテーブルを作成します（任意ですが推奨）。
+
+   ```bash
+   sudo fdisk /dev/sdX  # sdX は使用するドライブの識別子に置き換えてください
+   ```
+
+   - o を入力して新しい空の DOS パーティションテーブルを作成します
+
+   - n を入力して新しいパーティションを追加します
+
+   - プロンプトに従い、ディスク全体を使用するプライマリパーティションを作成します
+
+   - w を入力して変更を書き込み、終了します
+
+4. パーティションに対して LUKS 暗号化を初期化します。
+
+   ```bash
+   sudo cryptsetup luksFormat /dev/sdX1  # sdX1 は使用するパーティションに置き換えてください
+   ```
+
+   - 大文字で「YES」と入力して操作を確認するよう求められます
+
+   - 続いて、強力なパスフレーズを入力して確認します
+
+5. 暗号化されたパーティションを開きます。
+
+   ```bash
+   sudo cryptsetup luksOpen /dev/sdX1 encrypted_usb  # sdX1 は使用するパーティションに置き換えてください
+   ```
+
+   - 前のステップで設定したパスフレーズを入力します。
+
+6. 暗号化されたパーティション上にファイルシステムを作成します。
+
+   ```bash
+   sudo mkfs.ext4 /dev/mapper/encrypted_usb
+   ```
+
+   - 必要に応じて、`mkfs.btrfs` や `mkfs.xfs` といった他のファイルシステムを使用することもできます。
+
+7. 暗号化されたファイルシステムをマウントします。
+
+   ```bash
+   sudo mkdir -p /media/encrypted_usb
+   sudo mount /dev/mapper/encrypted_usb /media/encrypted_usb
+   ```
+
+### 暗号化されたドライブを安全にアンマウントする
+
+暗号化された USB ドライブを安全に取り外すには:
+
+1. ファイルシステムをアンマウントします。
+
+   ```bash
+   sudo umount /media/encrypted_usb
+   ```
+
+2. 暗号化されたパーティションを閉じます。
+
+   ```bash
+   sudo cryptsetup luksClose encrypted_usb
+   ```
+
+3. これで USB ドライブを安全に取り外すことができます。
+
+### 今後、暗号化されたドライブを使用する
+
+暗号化された USB ドライブを再度使用するには:
+
+1. USB ドライブを挿入します。
+
+2. 暗号化されたパーティションを開きます。
+
+   ```bash
+   sudo cryptsetup luksOpen /dev/sdX1 encrypted_usb  # sdX1 は使用するパーティションに置き換えてください
+   ```
+
+3. ファイルシステムをマウントします。
+
+   ```bash
+   sudo mount /dev/mapper/encrypted_usb /media/encrypted_usb
+   ```
+
+4. マウント／アンマウントをより簡単に行うには:
+
+   ```bash
+   # ~/.bashrc に追加します。sdX1 は使用するパーティションに置き換えてください
+   alias mount-encrypted='sudo cryptsetup luksOpen /dev/sdX1 encrypted_usb && sudo mount /dev/mapper/encrypted_usb /media/encrypted_usb'
+   alias unmount-encrypted='sudo umount /media/encrypted_usb && sudo cryptsetup luksClose encrypted_usb'
+   ```
+
+### 暗号化された USB ストレージのベストプラクティス
+
+1. 以下の条件を満たす強力なパスフレーズを選びます。
+
+    - 12 文字以上であること
+
+    - 大文字、小文字、数字、特殊文字を組み合わせていること
+
+    - 推測されやすい個人情報に基づいていないこと
+
+2. 暗号化されたドライブに保存している重要なデータのバックアップを保持してください。
+
+3. パスフレーズはパスワードマネージャーを使って安全に保管してください。
+
+4. ドライブを物理的に取り外す前には、必ず正しくアンマウントしてください。
+
+5. 機密性の高いデータについては、多要素認証の利用を検討してください。
+
+6. 暗号化されたドライブに保存している重要なデータは、定期的にバックアップを行ってください。

--- a/content/handbook/security/corporate/systems/1password/_index.md
+++ b/content/handbook/security/corporate/systems/1password/_index.md
@@ -1,0 +1,10 @@
+---
+title: 1Password
+upstream_path: /handbook/security/corporate/systems/1password/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+これはプレースホルダーページです。存在する子ページについては、以下のリンクをご覧ください。

--- a/content/handbook/security/corporate/systems/1password/group/_index.md
+++ b/content/handbook/security/corporate/systems/1password/group/_index.md
@@ -1,0 +1,10 @@
+---
+title: 1Password グループ
+upstream_path: /handbook/security/corporate/systems/1password/group/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+これはプレースホルダーページです。存在する子ページについては、以下のリンクをご覧ください。

--- a/content/handbook/security/corporate/systems/1password/passkey/_index.md
+++ b/content/handbook/security/corporate/systems/1password/passkey/_index.md
@@ -1,0 +1,10 @@
+---
+title: 1Password パスキーガイド
+upstream_path: /handbook/security/corporate/systems/1password/passkey/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+これはプレースホルダーページです。存在する子ページについては、以下のリンクをご覧ください。

--- a/content/handbook/security/corporate/systems/1password/setup/_index.md
+++ b/content/handbook/security/corporate/systems/1password/setup/_index.md
@@ -1,0 +1,32 @@
+---
+title: 1Password セットアップガイド
+upstream_path: /handbook/security/corporate/systems/1password/setup/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+入社初日に、利用開始のための招待メールが届きます。サービス別またはチーム別の Vault へのアクセスは、オンボーディングの中で、もしくはアクセスリクエストを通じて付与されます。
+
+追加のメリットとして、すべてのチームメンバーには無料の[ファミリーアカウント](https://support.1password.com/link-family/)も提供されており、業務用とは別のアカウント・Vault で個人のパスワードを保護できます。
+
+- [ベンダードキュメント - はじめに](https://support.1password.com/explore/team-member/)
+- [ベンダードキュメント - Mac への 1Password のインストール](https://support.1password.com/get-the-apps/?mac)
+- [1Password Chrome 拡張機能](https://chromewebstore.google.com/detail/1password-%E2%80%93-password-mana/aeblfdkhhhdcdjpifhhbdiojplfjncoa?hl=en&pli=1)
+- [ベンダードキュメント - Mac での利用開始](https://support.1password.com/getting-started-mac/)
+- [ベンダードキュメント - パスワードの保存と入力](https://support.1password.com/save-fill-passwords/)
+- [ベンダードキュメント - パスワードを安全に共有する](https://support.1password.com/share-items-security/)
+
+## トラブルシューティングのヒント
+
+### 管理者アカウントでの 1Password 拡張機能の連携
+
+副次的な 1Password アカウントへのアクセス権を持つユーザーは、Black Chrome プロファイル上の 1Password Chrome 拡張機能が、デスクトップアプリと自動連携する設定になっていないことを必ず確認してください。この設定は、1Password または Chrome のメジャーアップデート後に再び有効になる場合があります。
+
+1. Chrome の右上にある**プラグインアイコン**（パズルピース）をクリックし、1Password の隣にある**3 点ドット**メニューをクリックして、**設定**を選択します。
+2. 左サイドバーの **General** セクションで、`Integrate this extension with the 1Password desktop app` が無効になっていることを確認します。
+3. 左サイドバーで **Accounts & vaults** に移動します。
+4. 通常のユーザーアカウント（`{handle}-admin@gitlab.com` ではなく `{handle}@gitlab.com`）が表示されている場合は、3 点ドットをクリックして **Sign Out** を選択します。他に表示されているアカウント（個人の 1Password メールアドレスなど）についても、同じ操作を繰り返します。
+5. 管理者アカウントが表示されていない場合は、**Sign in to another account** をクリックします。1Password のウェブサイトにリダイレクトされたら、`gitlab.1password.com` のタイルを選び、`{handle}-admin@gitlab.com` のメールアドレスが表示されていることを確認した上で、マスターパスワードを入力します。
+6. 右上の 1Password 拡張機能に管理者の認証情報が表示されるようになります。

--- a/content/handbook/security/corporate/systems/1password/vault/_index.md
+++ b/content/handbook/security/corporate/systems/1password/vault/_index.md
@@ -1,5 +1,5 @@
 ---
-title: 1Password Vault
+title: 1Password ボルト
 upstream_path: /handbook/security/corporate/systems/1password/vault/
 upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
 translated_at: "2026-05-10T00:00:00Z"

--- a/content/handbook/security/corporate/systems/1password/vault/_index.md
+++ b/content/handbook/security/corporate/systems/1password/vault/_index.md
@@ -1,0 +1,10 @@
+---
+title: 1Password Vault
+upstream_path: /handbook/security/corporate/systems/1password/vault/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+これはプレースホルダーページです。存在する子ページについては、以下のリンクをご覧ください。

--- a/content/handbook/security/corporate/systems/accesschk/_index.md
+++ b/content/handbook/security/corporate/systems/accesschk/_index.md
@@ -1,0 +1,10 @@
+---
+title: アクセスチェック (accesschk)
+upstream_path: /handbook/security/corporate/systems/accesschk/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+これはプレースホルダーページです。存在する子ページについては、以下のリンクをご覧ください。

--- a/content/handbook/security/corporate/systems/accessctl/_index.md
+++ b/content/handbook/security/corporate/systems/accessctl/_index.md
@@ -1,0 +1,10 @@
+---
+title: アクセス制御 (access.gitlab.systems)
+upstream_path: /handbook/security/corporate/systems/accessctl/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+これはプレースホルダーページです。存在する子ページについては、以下のリンクをご覧ください。

--- a/content/handbook/security/corporate/systems/aws/billing/_index.md
+++ b/content/handbook/security/corporate/systems/aws/billing/_index.md
@@ -1,0 +1,10 @@
+---
+title: AWS の請求
+upstream_path: /handbook/security/corporate/systems/aws/billing/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-10T00:00:00Z"
+translator: claude
+stale: false
+---
+
+これはプレースホルダーページです。存在する子ページについては、以下のリンクをご覧ください。

--- a/translation-state/manifest.json
+++ b/translation-state/manifest.json
@@ -23089,6 +23089,76 @@
       "translated_at": "2026-05-10T00:00:00Z",
       "model": "claude-opus-4-7",
       "input_hash": "abe47959f7484841e4c9b051f73e3a8611fbf957795d9d142c605b2289574f81"
+    },
+    "content/handbook/security/corporate/systems/aws/billing/_index.md": {
+      "path": "content/handbook/security/corporate/systems/aws/billing/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "277513d2dd3a9a17405cf9075f17dd196cc9dd7977db63100db433275c21700e"
+    },
+    "content/handbook/security/corporate/systems/accessctl/_index.md": {
+      "path": "content/handbook/security/corporate/systems/accessctl/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "2e0077aad948f04f3361cd53c703a3f28cbc5ce9e9b8c48060cb605772bcf758"
+    },
+    "content/handbook/security/corporate/systems/accesschk/_index.md": {
+      "path": "content/handbook/security/corporate/systems/accesschk/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "7a8614a952fbf2eb4539f39a3f19db337fcb0e46aef72c8d360586176f5daabd"
+    },
+    "content/handbook/security/corporate/systems/1password/_index.md": {
+      "path": "content/handbook/security/corporate/systems/1password/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "0b4ab52db1031de887450f27706c5f141c03fb6156695ed3a0b764ea1769fede"
+    },
+    "content/handbook/security/corporate/systems/1password/vault/_index.md": {
+      "path": "content/handbook/security/corporate/systems/1password/vault/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "6b6c0b5f60753229faae5e0313e754cd19a7dac7e432d7d2e2f4891c53c70aed"
+    },
+    "content/handbook/security/corporate/systems/1password/setup/_index.md": {
+      "path": "content/handbook/security/corporate/systems/1password/setup/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "287f16abdda7b3495aeff975d63588e879fc0162a2dc3078e3a6dfad6f8e1a0b"
+    },
+    "content/handbook/security/corporate/systems/1password/passkey/_index.md": {
+      "path": "content/handbook/security/corporate/systems/1password/passkey/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "e2031c52e086172605827ccfc2346338203d162732acaff4f396c6b78afcdeb5"
+    },
+    "content/handbook/security/corporate/systems/1password/group/_index.md": {
+      "path": "content/handbook/security/corporate/systems/1password/group/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "d6e7309f0000bf202f73de06a7b246bc821d7aa7d2b40d2c2e459c6a6b305526"
+    },
+    "content/handbook/security/corporate/support/_index.md": {
+      "path": "content/handbook/security/corporate/support/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "522b80015a2b48b4cbab059a6fa93fe699d628b84616448ab0ffe3cea9f7dc50"
+    },
+    "content/handbook/security/corporate/support/usb-encryption/_index.md": {
+      "path": "content/handbook/security/corporate/support/usb-encryption/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-10T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "51fea8efed4fc21ec065e31a9545acac5728014174236b4cd8006b18326e8f76"
     }
   }
 }


### PR DESCRIPTION
## Summary
- 10 ファイル翻訳追加 (`content/handbook/security/corporate/` 配下: systems/aws/billing, systems/accessctl, systems/accesschk, systems/1password (+ vault/setup/passkey/group), support, support/usb-encryption)
- manifest 3477 → 3487 entries
- base = `translation/batch-2026-05-10-31` (PR #206)

## Test plan
- [x] manifest entries == content/ ファイル数 (3487)
- [x] ローカルで `hugo --renderToMemory --quiet` がエラーなく完了
- [x] フロントマター追跡フィールド付与確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 新しいコーポレートセキュリティサポートガイドを追加し、Tier 1〜5 の段階的なサポートフローを明記しました。
  * USB デバイス暗号化手順（macOS／Linux）ガイドを追加しました。
  * 1Password（セットアップ／Vault／Passkey／グループ）関連ドキュメントを整備しました。
  * アクセス制御／アクセスチェックや AWS 請求のプレースホルダーページを追加しました。
* **Chores**
  * 翻訳状態のマニフェストを更新しました（新規ページの翻訳メタデータ追加）。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyama0/gitlab-handbook-ja/pull/208)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->