### PR TITLE
translation: batch 2026-05-11-5 (laptop + access-requests + direction + automation)

### DIFF
--- a/content/handbook/security/corporate/automation/_index.md
+++ b/content/handbook/security/corporate/automation/_index.md
@@ -1,0 +1,8 @@
+---
+title: 自動化
+upstream_path: /handbook/security/corporate/automation/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-11T00:00:00Z"
+translator: claude
+stale: false
+---

--- a/content/handbook/security/corporate/direction/_index.md
+++ b/content/handbook/security/corporate/direction/_index.md
@@ -1,0 +1,10 @@
+---
+title: CorpSec の方向性
+upstream_path: /handbook/security/corporate/direction/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-11T00:00:00Z"
+translator: claude
+stale: false
+---
+
+Corporate Security の方向性にご関心をお寄せいただきありがとうございます。私たちの [direction](https://internal.gitlab.com/handbook/security/corporate/direction) と [roadmap with OKRs](https://internal.gitlab.com/handbook/security/corporate/direction) については、内部ハンドブックをご参照ください。

--- a/content/handbook/security/corporate/end-user-services/access-requests/_index.md
+++ b/content/handbook/security/corporate/end-user-services/access-requests/_index.md
@@ -1,0 +1,116 @@
+---
+title: アクセスリクエスト（AR）
+controlled_document: true
+tags:
+  - security_standard
+  - security_standard_acia
+upstream_path: /handbook/security/corporate/end-user-services/access-requests/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-11T00:00:00Z"
+translator: claude
+stale: false
+---
+
+{{< label name="Visibility: Audit" color="#E24329" >}}
+
+アクセスリクエストは IT チームが所有し、オンボーディング、オフボーディング、内部異動リクエストは People Operations チームが所有します。
+
+アクセスリクエストに関する質問がある場合は、Slack の #it_help またはツールのプロビジョナーにお問い合わせください。
+
+## アクセスリクエストに関連するページ
+
+- [よくある質問](/handbook/security/corporate/end-user-services/access-requests/#application-specific-templates)
+- [Tech Stack](https://gitlab.com/gitlab-com/www-gitlab-com/-/blob/master/data/tech_stack.yml)
+- [Baseline Entitlements](https://internal.gitlab.com/handbook/security/corporate/end-user-services/access-request/baseline-entitlements/)
+- [Temporary service providers access requests and onboarding](https://internal.gitlab.com/handbook/security/corporate/end-user-services/access-request/temporary-service-providers/)
+
+## はじめに
+
+すべてのオープンおよびクローズ済みの AR は [access-requests project](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/issues/) で確認でき、新しい Issue は [こちら](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/issues/new) から作成できます。
+
+新しい AR を作成すると、リクエストを満たすために必要な追加情報や追加の承認が必要かを正確に判断するため、さまざまなテンプレートから選択するオプションが与えられます。
+**各 Issue タイプに必要なすべてのラベルを追加するよう努めましたが、見落としがあるかもしれませんので、送信前にリクエストを再確認してください。**
+
+利用可能なテンプレートは多数ありますが、通常以下のいずれかのカテゴリに該当します。
+
+*利用可能なすべてのテンプレートの完全なリストは [こちら](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/tree/master/.gitlab/issue_templates) で確認できます*
+
+### 個別または一括アクセスリクエスト
+
+[個別または一括アクセスリクエスト](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/issues/new?description_template=Individual_Bulk_Access_Request) は、他のテンプレートが希望するものと一致しない場合に使用してください。
+
+このテンプレートは、すべての人が同じシステムへのアクセスをリクエストする限り、個人または複数人のアクセスをリクエストするのに使用できます。複数人が異なるシステムへのアクセスを必要とする場合は、複数の Issue を作成してください。
+
+### アクセス変更リクエスト
+
+[アクセス変更リクエスト](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/issues/new?description_template=Access_Change_Request) は、チームメンバーが現在プロビジョニング済みのシステムへのアクセスを必要としなくなった場合や、同じレベルのアクセスを必要としなくなった場合（管理者からユーザーへのアクセスダウングレードなど）に記録されます。
+追加情報については、GitLab ハンドブックの [`For Total Rewards Analysts: Processing Promotions & Compensation Changes`](/handbook/people-group/promotions-transfers/) セクションを参照してください。
+
+Okta にプロビジョニング／プロビジョニング解除の自動化が導入されているものの、これがアクセスのプロビジョニングおよびプロビジョニング解除の完全／正確な反映ではないことに注意することが重要です。
+Okta は、ユーザーの役割／グループに基づいて統合／実装されたアプリケーションを割り当てるように構成されています。
+これにより、Okta 経由でアプリケーションにアクセスできるようになりますが、ユーザーは依然としてシステムに直接アクセスできる可能性があります。
+Okta で設定されたアプリケーションのリストは [Okta Application Stack](https://gitlab.com/gitlab-com/www-gitlab-com/-/blob/master/data/tech_stack.yml) を参照してください。
+
+### アプリケーション固有のテンプレート
+
+これらの Issue は、特定のアプリケーションおよびサービス内またはそれらへのアクセスに関連します。たとえば、[1Password Request Form](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/issues/new?description_template=1Password_Request) を使用して既存のボルトやグループを変更したり、新しいものを作成したりできます。
+
+### 管理者（Black）アカウント
+
+私たちは Okta、1Password、Google Workspace などのさまざまなコアサービスへの管理者アクセスのプロビジョニングをサポートしています。このプロセスは、通常、まず新しいメールアドレスでの [管理者アカウントの作成](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/issues/new?description_template=Admin_Black_Account_Creation) のリクエストから始まります。
+管理者アカウントが作成されたら、特定のサービスへの管理者アクセスのため、追加の AR を提出する必要があります。
+
+- [管理者（Black）アカウント](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/issues/new?description_template=Admin_Black_Account_Creation)
+- [1Password 管理者](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/issues/new?description_template=Admin_Black_Account_Role_1Password)
+- [AWS 管理者](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/issues/new?description_template=Admin_Black_Account_Role_AWS)
+- [Google Workspace 管理者](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/issues/new?description_template=Admin_Black_Account_Role_GoogleWorkspace)
+- [Okta 管理者](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/issues/new?description_template=Admin_Black_Account_Role_Okta)
+
+### 名前変更リクエスト
+
+希望する名前を変更したい場合は、[このテンプレート](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/blob/master/.gitlab/issue_templates/Name_change_request.md) を使用できます。次に、People Ops チームと協力してすべてのシステムであなたの名前を更新し、新しいメールアドレスを提供します。
+
+### Baseline Entitlements
+
+これらの Issue は、新規入社者に適切なアクセスを割り当てるのに役立ちます。これらは多くの役割で自動的に作成され、通常追加の承認は必要ありません。ただし、自動化が Issue を作成しない場合、新規入社者のマネージャーが手動で Issue を作成する責任があります。
+
+Baseline Issue テンプレートのリストは [こちら](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/tree/master/.gitlab/issue_templates/role_baseline_access_request_tasks) で確認でき、自由にカスタマイズできます。
+
+Baseline Entitlement リクエストの作成に関する追加サポートについては、Slack の #it_help にお問い合わせください。
+
+## アクセスリクエストへの取り組み
+
+### 部門アクセスリクエストボード
+
+- 追加のラベルが必要な場合や、完全に自動化できるまでのプロセスの改善提案がある場合は、[Issue を作成](https://gitlab.com/gitlab-com/it/end-user-services/issues/it-help-issue-tracker/-/issues/new) してください。
+- AR は可能な限り、部門ごとに自動割り当てと自動ラベル付けが行われます。場合によっては、ツールごとに複数のプロビジョナーがいます。テンプレートが自動割り当てできない場合、Business Technology はプロビジョナーがラベル別に部門の Issue をレビューできるボード（例：`dept::to do`）を提供します。Issue を完了させるために誰が担当するかのワークフロー管理は、部門に委ねられています。
+- **Issue を 1 つの列から別の列に移動すると、最初のラベル（列ヘッダーごと）が削除され、2 番目のラベルが追加されます。Issue を列間で移動する際は注意してください。**
+- 部門は、以下のボードを表示することで、未解決のアクセスリクエスト Issue を確認できます。
+
+{{% panel header="**AR ボード：to-do：**" header-bg="success" %}}
+
+1. [Data](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1319045)
+1. [Finance](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1319048)
+1. [Infra](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1262513)
+1. [IT](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1262521)
+1. [Legal](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1319051)
+1. [PeopleOPs](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1318841)
+1. [Prod+Eng](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1319057)
+1. [Marketing](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1284066)
+1. [Sales](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1262518)
+1. [Security](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1319052)
+1. [Support](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1319053)
+{{% /panel %}}
+
+## Tech Stack の新しい項目にアクセスリクエストプロセスを追加する
+
+Tech Stack の新しい項目に対してアクセスリクエストプロセスを開始する必要がある場合：
+
+1. ツールが [tech stack](https://gitlab.com/gitlab-com/www-gitlab-com/-/blob/master/data/tech_stack.yml) に追加されていることを確認する
+1. チームメンバーが `provisioner` `deprovisioner` として含まれていることを確認する
+1. 関連するハンドブックページに、アクセスリクエストの提出が必要な要件を文書化する
+
+## 追加のヘルプ
+
+- 特定の SLA はありませんが、Issue で `@gitlab-com/gl-security/corp/helpdesk` をメンションしてください。
+- リクエストが緊急の場合、Slack の #it_help チャンネルで `it-help` をメンションし、緊急の理由を記載してください。

--- a/content/handbook/security/corporate/end-user-services/access-requests/access-requests/_index.md
+++ b/content/handbook/security/corporate/end-user-services/access-requests/access-requests/_index.md
@@ -1,0 +1,191 @@
+---
+title: "アクセスリクエスト（AR）"
+build:
+    list: never
+    render: never
+upstream_path: /handbook/security/corporate/end-user-services/access-requests/access-requests/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-11T00:00:00Z"
+translator: claude
+stale: false
+---
+
+アクセスリクエストは IT チームが所有し、オンボーディング、オフボーディング、内部異動リクエストは People Operations チームが所有します。
+
+アクセスリクエストに関する質問がある場合は、Slack の #it_help またはツールのプロビジョナーにお問い合わせください。
+
+## アクセスリクエストに関連するページ
+
+- [よくある質問](/handbook/security/corporate/end-user-services/access-requests/#application-specific-templates)
+- [Baseline Entitlements](https://internal.gitlab.com/handbook/security/corporate/end-user-services/access-request/baseline-entitlements/)
+- [Temporary service providers access requests and onboarding](https://internal.gitlab.com/handbook/security/corporate/end-user-services/access-request/temporary-service-providers/)
+
+## ヘルプが必要ですか？
+
+- 特定の SLA はありませんが、Issue で `@gitlab-com/gl-security/corp/helpdesk` をメンションしてください。
+- リクエストが緊急の場合、Slack の #it_help チャンネルで `it-help` をメンションし、緊急の理由を記載してください。
+
+## どのテンプレートを選べばよいですか？
+
+### 個別または一括アクセスリクエスト
+
+*[このテンプレート](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/issues/new?issuable_template=Individual_Bulk_Access_Request) は、すべての人が同じシステムへのアクセスをリクエストする限り、個人または複数人のアクセスをリクエストするのに使用できます。複数人が異なるシステムへのアクセスを必要とする場合は、同じテンプレートを使用して複数の Issue を作成してください。異なるマネージャーに報告するが同じ部門または部署の一部である複数人のアクセスをリクエストする場合、最高レベルのマネージャー、つまり部門または部署のディレクター、バイスプレジデント、またはエグゼクティブから承認を得ることができます。*
+
+{{% panel header="**手順**" header-bg="success" %}}
+アクセス情報をリクエストする人の詳細を使って、Issue のタイトルを `Full Name, System(s), Role` とつけてください。一括アクセスをリクエストする場合は、`Bulk Access, System(s), Role`。
+
+**ステップ 1. 個人情報**
+
+1. *個人情報：* アクセスをリクエストしている人のリストを提供してください。関連情報を含めてください。
+1. *SSH キー：* リクエストしているアクセスのタイプに必要な場合のみ、公開 SSH キーを追加してください。
+
+**ステップ 2. アクセスリクエスト**
+
+1. アクセスが必要なシステムの行を削除または追加してください。**テンプレートの形式に必ず従ってください（以下にも記載）**。アクセスをリクエストする役割、ボルト、グループ、チャンネル、プロジェクトを追加して、リクエストするアクセスを可能な限り具体的にしてください。
+1. 管理者アクセスが付与される場合、admin-access ラベルを追加してください。[最小権限レビュー](https://internal.gitlab.com/handbook/security/access-management-standard/#least-privilege-reviews-for-access-requests) に従って必要な最小限のアクセスをリクエストし、根拠セクションでアクセスが必要な理由を説明してください。
+1. リクエストが Infrastructure チームが所有するシステム（[tech stack](https://gitlab.com/gitlab-com/www-gitlab-com/-/blob/master/data/tech_stack.yml) による）へのアクセスを含む場合、`@gitlab-com/gl-infra/managers` をメンションし、~InfrastructureApproved ラベルを追加することで承認を依頼してください。
+
+   ```text
+   - [ ] System name: Which vault, which group, which channel, which project, which role?
+   - Justification for this access: Please explain why this access is needed.
+   ```
+
+**ステップ 3：承認のためマネージャーに割り当てる**
+
+1. レポートの一人のためにアクセスをリクエストしているマネージャーの場合は、ステップ 4 にスキップしてください。
+1. Issue にラベル `AR-Approval::Needs Manager Approval` を追加してください。
+1. Issue をマネージャーに割り当ててください。異なるマネージャーに報告するが同じ部門または部署の一部である複数人のアクセスをリクエストする場合、最高レベルのマネージャー、つまり部門または部署のディレクター、バイスプレジデント、またはエグゼクティブから承認を得ることができます。
+
+**ステップ 4：マネージャーがすべきこと**
+
+1. この人物のマネージャーである場合、Issue にラベル `AR-Approval::Manager Approved` と `ReadyForProvisioning` を追加してください。アクセスをリクエストしている本人の場合、承認のため*あなたの*マネージャーに割り当てる必要があり、彼らが `AR-Approval::Manager Approved` と `ready for provisioning` のラベルを追加する必要があります。
+1. 承認後、[tech stack に記載された](https://gitlab.com/gitlab-com/www-gitlab-com/-/blob/master/data/tech_stack.yml) **Issue をシステムプロビジョナーに割り当てる** 必要があります。
+
+**ステップ 5：プロビジョナーがすべきこと**
+
+1. プロビジョニングする前に、チームメンバーには機能を実行するために必要な最小限のアクセスのみが付与されるべきであることを考慮してください。アクセスレベルが必要かどうか、またはより低いアクセスレベルで十分かを判断してください。
+1. アクセスレベルが適切な場合、AR-Approval::Manager Approved ラベルが存在することを確認した上で、アカウントのプロビジョニングを進めてください。
+1. ステップ 2 で、プロビジョニングしたシステムにチェックを入れてください。
+1. 管理者アクセスが付与される場合、Security Operations が誰が管理者アクセスを持っているかを把握できるよう、このリクエストに admin-access ラベルを追加してください。
+   - GitLab.com に管理者アクセスが付与される場合、ユーザーが GitLab Instance Administrators グループに追加されていることを確認してください
+   - ユーザーに 2fa が必要であることと、すぐにセットアップしないとロックアウトされることを通知してください
+{{% /panel %}}
+
+---
+
+### 共有アカウントアクセスリクエスト
+
+{{% panel header="**手順**" header-bg="success" %}}
+**この Issue リクエストを送信する前に**
+
+1. リクエストが GitLab のポリシーと手順に沿っていることを確認するため、[アクセス制御ポリシーと手順](/handbook/security/) をご覧ください。レビュー後、共有アカウントが依然として必要であると判断した場合、テンプレートを使用して Issue を提出してください。**PCI データを含むシステムでは共有アカウントは認められないことに注意してください。**
+1. 共有アカウントリクエストは、IT Ops と記載された Tech Stack オーナーによってレビューおよび承認される必要があることに注意してください。
+**追加をリクエストする各ユーザーに対して [Exception Request](https://gitlab.com/gitlab-com/gl-security/security-assurance/sec-compliance/compliance/issues/new?issuable_template=Exception%20Request) を記録する必要があります。** Exception Request の最大例外期間は 90 日（デバイスの例外のみ 365 日）であることに注意してください。
+例外期間後は、レビューおよび承認のための別の Exception Request を提出する必要があります。**Exception Request が記録、レビュー、承認されない場合、共有アカウントは無効化されることに注意してください。** 詳細については、[情報セキュリティポリシー例外管理プロセス](/handbook/security/controlled-document-procedure/#exceptions) ハンドブックページをご参照ください。
+
+**この Issue リクエストの送信方法**
+
+1. あなたの情報を使って、Issue のタイトルを「Shared Account Request, Role, System(s)」とつけてください。
+1. `User Details` セクションを記入し、必要に応じて**行を削除または追加**してください。
+1. アクセスが必要なシステムについて**行を追加**し、希望のシステムのみが Issue に残るようにしてください。**チェックは入れないでください。**
+   - *[最小権限レビュー](https://internal.gitlab.com/handbook/security/access-management-standard/#least-privilege-reviews-for-access-requests) に従って必要な最小限のアクセスをリクエストし、根拠セクションでアクセスが必要な理由を説明し、リクエストする役割を指定してください。具体的に記述してください。*
+1. この人物のマネージャーである場合、Issue にラベル `AR-Approval::Manager Approved` と `ready for provisioning` を追加してください。アクセスをリクエストしている本人の場合、承認のため*あなたの*マネージャーに割り当てる必要があり、彼らが `AR-Approval::Manager Approved` と `ready for provisioning` のラベルを追加する必要があります。
+1. 承認後、[tech stack に記載された](https://gitlab.com/gitlab-com/www-gitlab-com/-/blob/master/data/tech_stack.yml) **Issue をシステムプロビジョナーに割り当てる** 必要があります。
+1. 完了したら Issue を閉じてください。
+{{% /panel %}}
+
+#### 共有アカウントに対する IT 向けの手順とガイダンス
+
+1. 共有アカウントアクセスリクエストをレビューし、共有アカウントに追加される各ユーザーに対して [Exception Request](https://gitlab.com/gitlab-com/gl-security/security-assurance/sec-compliance/compliance/issues?scope=all&utf8=%E2%9C%93&state=opened&label_name[]=Exception%20Request) があることを確認してください。Exception Request をレビューし、アクセスリクエスト Issue に例外期間を文書化してください。承認を追加するか共有アカウントを設定する前に、Exception Request が Security によってレビューおよび承認されていることを確認してください。
+1. すべての共有アカウントは Okta を介して管理される必要があります。1Password を使用する必要がある場合（Okta が技術的に不可能な場合）、これをアクセスリクエストに記載する必要があります。
+1. 共有アカウントが Okta で管理される場合 - 例外タイムラインに応じて Okta でレビュー／リマインダー日を設定し、共有アカウントアクセスをレビューして Issue を閉じてください。
+   1. タイムライン期間が満了に近づいていることに関する Okta からの通知を受信した場合、新しい共有アカウントアクセスリクエストを記録し、共有アカウントオーナーに割り当てて完了させてください。
+1. 共有アカウントが 1Password で管理される場合 - 例外タイムラインに応じて期日を追加し、Issue を開いたままにしてください。
+   1. タイムライン期間が満了に近づいていることに関する `GitLab.com` からの通知を受信した場合、既存の Issue を閉じ、新しい共有アカウントアクセスリクエストを記録し、共有アカウントオーナーに割り当てて完了させてください。
+
+---
+
+### アクセス変更リクエスト
+
+アクセス変更リクエストは、チームメンバーが現在プロビジョニング済みのシステムへのアクセスを必要としなくなった場合や、同じレベルのアクセスを必要としなくなった場合（管理者からユーザーへのアクセスダウングレードなど）に記録されます。
+追加情報については、GitLab ハンドブックの [`For Total Rewards Analysts: Processing Promotions & Compensation Changes`](/handbook/people-group/promotions-transfers/) セクションを参照してください。
+
+Okta にプロビジョニング／プロビジョニング解除の自動化が導入されているものの、これがアクセスのプロビジョニングおよびプロビジョニング解除の完全／正確な反映ではないことに注意することが重要です。
+Okta は、ユーザーの役割／グループに基づいて統合／実装されたアプリケーションを割り当てるように構成されています。
+これにより、Okta 経由でアプリケーションにアクセスできるようになりますが、ユーザーは依然としてシステムに直接アクセスできる可能性があります。
+Okta で設定されたアプリケーションのリストは [Okta Application Stack](https://gitlab.com/gitlab-com/www-gitlab-com/-/blob/master/data/tech_stack.yml) を参照してください。
+
+これは以下を意味します：
+
+1. GitLab チームメンバーが別の役割に異動する。
+1. Workday のチームメンバーのプロファイルが変更される。
+1. このプロファイル変更により、自動的にチームメンバーの Okta プロファイルにも対応する変更がトリガーされる。
+1. これにより、チームメンバーは新しい部門と役割に基づいて新しいアプリケーションに割り当てられる。
+1. 同時に、新しい役割に関係のない古いアプリケーションはすべて取り消し／割り当て解除される。
+1. さらに、Okta 管理者は Okta から、ユーザープロファイルに変更があったことを示すメールを受信する（メール件名：1 existing user updated）。Okta の自動化はバックグラウンドですでに行われており、このメールは情報提供のみです。
+
+このアプリケーション自動化は Okta で行われますが、「真の」システムプロビジョニングおよびプロビジョニング解除は、影響を受けるシステム内でアクセス変更リクエストを介して手動で完了する必要があります。
+
+---
+
+### Google Groups、1Password ボルトまたはグループのアクセスリクエスト
+
+*[このテンプレート](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/issues/new?issuable_template=googlegroup_1Passwordgroupvault) は、すべての人が同じシステムへのアクセスをリクエストする限り、個人または複数人のアクセスをリクエストするのに使用できます。複数人が異なるシステムへのアクセスを必要とする場合は、同じテンプレートを使用して複数の Issue を作成してください。異なるマネージャーに報告するが同じ部門または部署の一部である複数人のアクセスをリクエストする場合、最高レベルのマネージャー、つまり部門または部署のディレクター、バイスプレジデント、またはエグゼクティブから承認を得ることができます。*
+
+{{% panel header="**手順**" header-bg="success" %}}
+
+1. **タイトル** Issue「Full Name - System - Role」（例：Laura Croft Google Group: adventurer）
+1. 必要なアクセスについて**行を削除または追加**してください。
+1. これが以下のリクエストである**場合**、ラベルによる承認を得るためマネージャーに割り当ててください（彼らはラベル `AR-Approval::Manager Approved` と `ReadyForProvisioning` を適用する必要があります）：
+   - 1Password ボルトまたはグループへのアクセス
+   - 管理者アクセス
+   - 内部以外の人物（共有 Slack チャンネルを含む）への Slack グループへのアクセス
+   - 内部以外の人物が Slack チャンネルから削除され、再度アクセスをリクエストしている場合、新しいアクセスリクエストとマネージャー承認が必要であることに注意してください
+1. 完了したら Issue を**閉じて**ください。
+{{% /panel %}}
+
+---
+
+### 名前変更リクエスト
+
+*名前が変更された場合に、[このテンプレート](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/blob/master/.gitlab/issue_templates/Name_change_request.md) を使用できます。*
+
+{{% panel header="**手順**" header-bg="success" %}}
+
+1. Issue のタイトルを `Full Previous Name to Full New Name - Name Change Request` とつけてください。
+1. Issue テンプレートに記載されているように、該当するすべてのセクションを完了してください。
+{{% /panel %}}
+
+---
+
+## アクセスリクエストへの取り組み
+
+### 部門アクセスリクエストボード
+
+- 追加のラベルが必要な場合や、完全に自動化できるまでのプロセスの改善提案がある場合は、[Issue を作成](https://gitlab.com/gitlab-com/it/end-user-services/issues/it-help-issue-tracker/-/issues/new) してください。
+- AR は可能な限り、部門ごとに自動割り当てと自動ラベル付けが行われます。場合によっては、ツールごとに複数のプロビジョナーがいます。テンプレートが自動割り当てできない場合、Business Technology はプロビジョナーがラベル別に部門の Issue をレビューできるボード（例：`dept::to do`）を提供します。Issue を完了させるために誰が担当するかのワークフロー管理は、部門に委ねられています。
+- **Issue を 1 つの列から別の列に移動すると、最初のラベル（列ヘッダーごと）が削除され、2 番目のラベルが追加されます。Issue を列間で移動する際は注意してください。**
+- 部門は、以下のボードを表示することで、未解決のアクセスリクエスト Issue を確認できます。
+
+{{% panel header="**AR ボード：to-do：**" header-bg="success" %}}
+
+1. [Data](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1319045)
+1. [Finance](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1319048)
+1. [Infra](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1262513)
+1. [IT](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1262521)
+1. [Legal](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1319051)
+1. [PeopleOPs](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1318841)
+1. [Prod+Eng](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1319057)
+1. [Marketing](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1284066)
+1. [Sales](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1262518)
+1. [Security](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1319052)
+1. [Support](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/boards/1319053)
+{{% /panel %}}
+
+## Tech Stack の新しい項目にアクセスリクエストプロセスを追加する
+
+Tech Stack の新しい項目に対してアクセスリクエストプロセスを開始する必要がある場合：
+
+1. ツールが [tech stack](https://gitlab.com/gitlab-com/www-gitlab-com/-/blob/master/data/tech_stack.yml) に追加されていることを確認する
+1. チームメンバーが `provisioner` `deprovisioner` として含まれていることを確認する
+1. 関連するハンドブックページに、アクセスリクエストの提出が必要な要件を文書化する

--- a/content/handbook/security/corporate/end-user-services/access-requests/frequently-asked-questions.md
+++ b/content/handbook/security/corporate/end-user-services/access-requests/frequently-asked-questions.md
@@ -1,0 +1,85 @@
+---
+title: "アクセスリクエスト（AR）FAQ"
+upstream_path: /handbook/security/corporate/end-user-services/access-requests/frequently-asked-questions/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-11T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## ヘルプが必要ですか？
+
+- 特定の SLA はありませんが、Issue で `@gitlab-com/business-technology/end-user-services` をメンションしてください。
+- リクエストが緊急の場合、Slack の #it_help チャンネルで `it-help` をメンションし、緊急の理由を記載してください。
+
+## アクセスが必要
+
+### AR リクエストが長く開いたままです、どうすれば対応してもらえますか？
+
+1. アクセスリクエストが [手順](/handbook/security/corporate/end-user-services/access-requests/access-requests#how-do-i-choose-which-template-to-use) に従って完了されており、アクセスが必要なシステム／ボルト／グループ／プロジェクトと、必要な役割または権限が含まれていることを確認してください。
+1. ほとんどのアクセスリクエストにはマネージャーの承認が必要なので、AR でマネージャーをタグ付けし、Issue に ~"AR-Approval::Manager Approved" と ~"ReadyForProvisioning" のラベルを追加するように依頼してください。
+1. アクセスをリクエストしているツールの正しいプロビジョナーに Issue をタグ付けして割り当てたことを確認してください。すべてのツールのプロビジョナーは [Tech Stack](https://gitlab.com/gitlab-com/www-gitlab-com/-/blob/master/data/tech_stack.yml) で確認できます。
+1. プロビジョナーが IT チームの場合、AR に ~"IT::to do" ラベルを必ず追加してください。
+1. 上記のすべての手順に従ってもアクセスリクエストが対応されない場合、ツールを所有するチームに Slack チャンネルで連絡してください。各チームの Slack チャンネルは [Tech Stack](https://gitlab.com/gitlab-com/www-gitlab-com/-/blob/master/data/tech_stack.yml) で確認できます。
+
+### システムまたはグループ／ボルトへのアクセスが必要ですか？
+
+1. ニーズに基づいてテンプレートを選択する：ほとんどの人は [Bulk](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/issues/new?issuable_template=Bulk_Access_Request) または [Single Person](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/issues/new?issuable_template=Individual_Bulk_Access_Request) テンプレートを使用します。
+1. オンボーディング中に見落とされた場合を除き、Baseline Entitlement の一部であるものに対してアクセスリクエストを開かないでください。
+    1. [全チームメンバーの baseline entitlements](https://internal.gitlab.com/handbook/security/corporate/end-user-services/access-request/baseline-entitlements/#baseline-entitlements-all-gitlab-team-members)
+    1. [役割ベースの baseline entitlements](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/tree/master/.gitlab/issue_templates/role_baseline_access_request_tasks)
+1. **以下に該当しない限り**、Issue にラベル `AR-Approval::Manager Approved` が必要です：
+    1. Google Workspace のメールエイリアスまたはグループに追加される内部チームメンバー
+    1. Slack グループに追加される内部チームメンバー
+    1. 完全に変更されていない役割ベースの baseline entitlement
+1. [システムへのアクセスをプロビジョニングする人](https://gitlab.com/gitlab-com/www-gitlab-com/-/blob/master/data/tech_stack.yml) に Issue を必ず割り当ててください。
+1. ヘルプが必要な場合は、ヘルプが必要な Issue へのリンクとともに、Slack チャンネル #it-help で IT-Ops に質問してください。
+1. 業務を行うために必要な最小限のアクセスのみをリクエストしてください。
+
+### マネージャーの承認が必要ですか？場合によります
+
+以下をリクエストしている場合、マネージャーの承認は不要です：
+
+1. Google Workspace のメールエイリアスまたはグループに追加される内部チームメンバー（そのグループが Google Cloud Platform への権限を提供する場合を除く）
+1. Slack グループに追加される内部チームメンバー
+1. 役割ベースの entitlement に含まれているもの
+
+### Rails またはデータベースの本番コンソール（grpd）へのアクセスが必要
+
+Teleport を使用して、いずれかへの一時的なアクセスをリクエストしてください
+[Rails コンソール](https://gitlab.com/gitlab-com/runbooks/-/blob/master/docs/teleport/Connect_to_Rails_Console_via_Teleport.md) または
+[データベースコンソール](https://gitlab.com/gitlab-com/runbooks/-/blob/master/docs/teleport/Connect_to_Database_Console_via_Teleport.md)。
+
+### version.gitlab.com へのアクセスが必要
+
+すでにお持ちかもしれません：[dev アカウントを持っているかテストしてください。](https://dev.gitlab.org/)
+
+- dev アカウントが必要な場合は、[Single Person Access Request](https://gitlab.com/gitlab-com/team-member-epics/access-requests/-/issues/new?issuable_template=Individual_Bulk_Access_Request) を作成してください。
+- dev アカウントを持っている場合は、[version](https://version.gitlab.com/users/sign_in) にアクセスし、GitLab でログインして資格情報の使用を承認してください。
+
+### Light Agent として Zendesk へのアクセスが必要
+
+Zendesk Light アクセスのアクセスリクエストを作成する必要はありません。[メールでアクセスを取得するための手順に従ってください](/handbook/support/internal-support/)
+
+### メールエイリアスを追加、または名前を変更する必要がある
+
+メールエイリアスの追加や名前変更には、[`slack_googlegroup_1password` AR テンプレート](https://gitlab.com/gitlab-com/team-member-epics/access-requests/issues/new?issuable_template=slack_googlegroup_1Passwordgroupvault) を使用してください。
+リクエストできる内容や数に制限はありませんが、追加または変更について短い説明を含めてください。一部のエイリアスリクエストは、不適切と判断された場合、または運用の判断で拒否される場合があります。
+
+このアプリケーション自動化は Okta で行われますが、「真の」システムプロビジョニングおよびプロビジョニング解除は、影響を受けるシステム内でアクセス変更リクエストを介して手動で完了する必要があります。
+
+### 古いアクセスリクエストを閉じる
+
+アクセスリクエストはできるだけ早く完了されることが期待されます（30 日）。
+
+作成から 30 日を超えるとアクセスリクエストを自動的に閉じるパイプラインが設定されています。
+これは、古い AR を減らし、バックログをクリアするためです。例外として、AR に `AccessReview` ラベルがある場合、パイプラインはそのラベルがある場合は Issue を無視します。
+このパイプラインは Issue にコメントを追加し、それが自動的に閉じられていることと、残りのタスクがある場合にチームメンバーが何をすべきかを記載します。
+
+現在、パイプラインは毎週金曜日の午後 9 時 30 分に実行されるようスケジュールされています。30 日経過したすべてのアクセスリクエスト Issue を閉じます。
+
+ご注意：これは AR 自動クローザーの最初のイテレーションです。私たちのチームはこれを洗練し改善するために取り組んでいきます。
+
+### 既存のアクセスを削除する必要がある
+
+どのアクセスと誰を削除する必要があるかを指定したアクセスリクエストを作成してください。

--- a/content/handbook/security/corporate/end-user-services/laptop-management/laptop-offboarding-returns/_index.md
+++ b/content/handbook/security/corporate/end-user-services/laptop-management/laptop-offboarding-returns/_index.md
@@ -1,0 +1,73 @@
+---
+title: "ラップトップのオフボーディングと返却"
+upstream_path: /handbook/security/corporate/end-user-services/laptop-management/laptop-offboarding-returns/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-11T00:00:00Z"
+translator: claude
+stale: false
+---
+
+チームメンバーが GitLab 支給のラップトップを保持する資格がない場合、GitLab の在庫に返却するようリクエストするか、割引価格で購入するオプションを提供することがあります。古いラップトップを保持する資格はあるものの保持しないことを選ぶメンバーに対するオプションも提供しています。
+
+### ラップトップのオフボーディング
+
+GitLab の判断により、以下の条件下では会社支給のデバイスを無償で保持できる場合があります。
+
+* ラップトップが少なくとも 3 年間使用されており、更新が承認されている
+* チームメンバーが早期交換時に古いラップトップを保持する許可を EUS から受けている
+* 元チームメンバーがオフボーディング時点で少なくとも 1 年間アクティブに使用していた
+* オフボーディング時点でデバイスの使用期間が 1 年未満である元チームメンバーが、PeopleOps と EUS から古いラップトップの保持承認を受けている
+
+{{% alert title="**重要**" color="warning" %}}
+
+保持されるすべてのラップトップは、デバイスの所有権を譲渡する前に EUS によってワイプされる必要があります。詳細は [Laptop Wipe](/handbook/security/corporate/end-user-services/laptop-management/laptop-wipe/) ページをご覧ください。
+
+{{% /alert %}}
+
+### ラップトップの返却
+
+GitLab の判断により、以下の条件下では会社支給のデバイスの返却をリクエストする場合があります。
+
+* メンバーがオフボーディング時点でラップトップを 1 年未満しか所持していない
+* メンバーがオフボーディング時点で雇用条件に違反していたことが判明した
+* メンバーが調査、不正行為、解雇事由のある解雇、GitLab’s Code of Business Conduct & Ethics の違反、その他の法的またはセキュリティ関連の調査に関与している
+* EUS チームがオフボーディングされたチームメンバーに対する現在のホールド通知を受けている場合、進める前に内部で協議する必要があります
+* 古いラップトップが 3 年未満である承認済みのラップトップ交換
+
+EUS は返却を促進するため、現在の配送先住所、電話番号、ユーザーの可用性を確認する必要があります。GitLab は返却に関連するすべての費用を負担し、別途要求がない限り返却キットを提供できます。最終日前に段ボール箱と緩衝材を購入し、Navan で「Office supplies & consumables」として経費精算することもできます。IT がラップトップを返却するためのプリペイド配送ラベルを提供します。
+
+> ハードウェア返却の場合、私たちのベンダーが追加情報やリクエストのため直接連絡することがあります。
+
+### ラップトップの買い取り
+
+>チームメンバーが調査、不正行為、解雇事由のある解雇、[GitLab’s Code of Business Conduct & Ethics](https://ir.gitlab.com/governance/governance-documents/default.aspx) の違反、その他の法的またはセキュリティ関連の調査に関与している場合、ラップトップを購入または無償で保持するオプションは無効になる場合があります。
+
+チームメンバーがオフボーディング時点で 1 暦年を完了していない、または過去 1 年以内にラップトップの更新を受けている場合、GitLab の判断により、現在の正味価値で GitLab からラップトップを購入するオプションがあります。チームメンバーがラップトップをオフボーディング時点で 1 年以上使用している場合、GitLab の判断により、無償で保持することを選ぶことができます。これは、ラップトップのワイプを可能にし、適用される法的義務によって必要とされる場合は保存目的でイメージング作成を可能にするため、オフボーディング過程で会社と速やかに協力することが条件となります。GitLab がチームメンバーのコンピュータの保存目的のイメージを作成する必要がある場合、コンピュータをプリペイドパッケージで GitLab Corporate Security に送付するか、リモートで [Backblaze](/handbook/security/corporate/systems/backblaze/) を介して達成される場合があります。
+
+チームメンバーがラップトップの購入を希望し、会社が同意した場合、プロセスを開始するため laptops@gitlab.com にメールを送る必要があります。購入する場合、IT のマネージャーまたは Lead IT Analyst が承認し、決定された価値をチームメンバーにメールで送付できます。チームメンバーが購入を進めることを決定した場合、経理部門が支払い情報について連絡します。
+
+退職するチームメンバーがラップトップを保持または [寄付](#laptop-donations) しないことを選択した場合、GitLab に [返却](#laptop-returns) できます。
+
+**チームメンバーがアクティブな Legal Hold の対象であるか、アクティブな会社調査に関連する資料を所有している場合、通知の要件に従う必要があります。アクティブな Legal Hold の遵守を怠ると、チームメンバーまたは会社が民事または刑事罰や制裁を含む不利な結果にさらされる可能性があります。通知に概説された手順に従う義務は、ホールドが解除されるまで継続し、たとえチームメンバーが会社を退職しても続きます。チームメンバーが会社を退職する場合、すべての会社デバイスとアクティブな Legal Hold Notice またはアクティブな会社調査に従って保持しているすべての資料は、退職時に引き渡される必要があります。**
+
+### ラップトップの寄付
+
+ハードウェアの寄付は、不利な地域や代表性が乏しいグループの人々にテクノロジー学習へのアクセスを提供することで、デジタルデバイドを橋渡しするのに役立ちます。GitLab は、3 年間の使用後に [厳選されたリストのベンダー](https://docs.google.com/spreadsheets/d/15g4v5coC_yLlVNTKUZMwATllZhxzqbxrtvwJsi8bjXE/edit#gid=0) に使用済みデバイスを寄付するオプションを提供しています。この厳選されたリストは、[Upstream Diversity Working Group](/handbook/company/working-groups/upstream-diversity/) の成果です。
+
+リストにあるベンダーは、以下の基準を満たしています。
+
+* フォーカスグループが不利な地域および／または代表性が乏しいグループの人々であること
+* 非営利であること
+* 価値観が GitLab の CREDIT の価値観と一致していること
+* 「ネガティブプレス」チェック（Google の最初の 2 ページ）に合格していること
+
+GitLab チームメンバーとして、基準に沿ったベンダーを追加したい場合は、[ベンダーシート](https://docs.google.com/spreadsheets/d/15g4v5coC_yLlVNTKUZMwATllZhxzqbxrtvwJsi8bjXE/edit#gid=0) にコメントしてください。
+
+#### プロセス
+
+1. [ラップトップの更新](/handbook/security/corporate/end-user-services/laptop-management/laptop-ordering/#laptop-refreshes) Issue を作成する際、ラップトップを寄付したい旨と、どの [承認済みベンダー](https://docs.google.com/spreadsheets/d/15g4v5coC_yLlVNTKUZMwATllZhxzqbxrtvwJsi8bjXE/edit#gid=0) かを示すことができます
+    1. オフボーディングの場合は、[メール](mailto:laptops@gitlab.com) でお問い合わせいただき、お手伝いできるかどうかをお知らせください。
+1. Issue にどのロジスティクスのオプションが使用されるかを示してください：地元での持ち込み、または宅配便での発送。
+1. セキュリティ上の理由から、持ち込みまたは発送前に [ラップトップのワイプ](/handbook/security/corporate/end-user-services/laptop-management/laptop-wipe/) プロセスが完了していることを確認してください。
+
+質問や懸念がある場合は、Slack の #it_help チャンネルまたは laptops@gitlab.com 宛にメールでお問い合わせください。

--- a/content/handbook/security/corporate/end-user-services/laptop-management/laptop-ordering/_index.md
+++ b/content/handbook/security/corporate/end-user-services/laptop-management/laptop-ordering/_index.md
@@ -1,0 +1,114 @@
+---
+title: ラップトップの発注
+upstream_path: /handbook/security/corporate/end-user-services/laptop-management/laptop-ordering/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-11T00:00:00Z"
+translator: claude
+stale: false
+---
+
+CorpSec ヘルプデスクチームがすべてのラップトップ発注プロセスを担当します。自己調達は、ラップトップを配送できない地域にいる場合のみ利用可能です。
+
+## 配送地域
+
+以下の国に居住するチームメンバーは、IT のラップトップ発注プロセスでサービスを利用できます。
+
+北米、EU の大部分、英国、タイ、日本、フィリピン、シンガポール、オーストラリア、ニュージーランド、インド、イスラエル、コスタリカ、韓国。
+
+私たちはベンダー関係をグローバルに拡大するにつれ、サポート対象国を追加していきます。
+現在、ブラジル、チリ、ケニア、アルメニア、ウクライナではラップトップを調達できません。
+
+チームメンバーの国が上記に記載されていない場合や、ラップトップ調達に関する一般的な質問については、laptops@gitlab.com または Candidate Experience Specialist までお問い合わせのうえ、代替オプションについてご相談ください。
+チームメンバーがハードウェア購入のための財政支援を必要とする場合、会社が購入を促進するために資金を前払いすることができます（後述の例外プロセスを参照）。
+
+## ラップトップの購入と配送プロセス
+
+End User Services があなたのラップトップ発注を受領後、リクエストの作業を開始します。新規入社者は、入社日の前週に GitLab のラップトップが届くと予想できます。私たちはこれをリモートで実現するため、世界中のさまざまなベンダーとビジネス関係を活用しています。配送時間は、所在地、ハードウェアの供給状況、ベンダーの選定、配送方法によって変動することにご注意ください。
+
+>私たちのパフォーマンス KPI は、新規入社者のラップトップの 90% 以上を入社日前に届けることを目標としています。メトリクスは [このハンドブックページ](https://internal.gitlab.com/handbook/it/end-user-services/gitlab-laptop-metrics/) で内部的に追跡されています。
+
+## 新規入社者のラップトップ発注プロセス
+
+新規入社者向けのラップトップ発注プロセスは、Candidate Experience Specialist から最初のウェルカムメールが送信されると開始されます。メールには、GitLab 支給のラップトップをリクエストするためのリンクが含まれます。遅延を避けるため、できるだけ早くフォームに記入してください。
+
+新規入社者がフォームを記入すると、入社日の前週にラップトップが届くと予想できます。私たちはこれをリモートで実現するため、世界中の複数のベンダーとビジネス関係を活用しています。**ご注意：配送時間は、所在地、ハードウェアの供給状況、ベンダーの選定、配送方法によって変動します。**
+
+場合によっては、優先配送や翌日配送を手配できる可能性もあります。すべてのケースおよび地域でこれが提供できるとは限りません。これが必要な場合は、`laptops@gitlab.com` までご連絡いただくか、Candidate Experience Specialist と利用可能な全オプションについてご相談ください。
+
+採用マネージャーや採用／リクルーティングチームのメンバーは、[IT Equipment Order Process Project](https://gitlab.com/gitlab-com/it/end-user-services/issues/it-equipment-order-processing/-/issues/?sort=created_date&state=all&first_page_size=100) で新規入社者の発注ステータスや内容を確認できます。
+
+ラップトップリクエストの発送までの最短処理時間。一部の国では、配送に必要な書類により時間がかかる場合があります。
+
+* 北米の新規入社者 - 2 週間（Apple）と 5 週間（Linux）
+* EMEA／APAC の新規入社者 - 2 週間（Apple）と 5 週間（Linux）
+* その他の地域 - 3 週間（Apple）と 9 週間（Linux）
+
+新規 GitLab チームメンバーが入社日にラップトップを利用できない場合、採用マネージャーまたは採用／リクルーティングチームのメンバーは、新規入社者が個人の macOS または Linux ラップトップを一時的に使用できるよう [security exception](https://gitlab.com/gitlab-com/gl-security/security-assurance/security-compliance-commercial-and-dedicated/exceptions/-/issues/new?description_template=exception_request) をリクエストする必要があります。
+
+まれに、入社日前にラップトップが破損または使用できない状態で到着した場合、Candidate Experience Specialist にご連絡いただき、即時の交換または修理について次のステップを確認するため [laptops@gitlab.com](mailto:laptops@gitlab.com) を CC に入れてください。
+
+{{% alert title="**警告：偽の求人詐欺**" color="warning" %}}
+詐欺師が GitLab を装い、求職者を狙うことがあります。GitLab が新規入社者に機材購入のための資金を送るように依頼することは決してありません。
+
+警告サインと自己防衛の方法を学ぶには、["What to know about a fake job scam impersonating GitLab"](https://about.gitlab.com/blog/2023/06/29/fake-gitlab-job-scam/) のブログ記事をお読みください。
+
+{{% /alert %}}
+
+## ラップトップの更新
+
+> **注意**：ほとんどの場合、私たちは更新よりも新規入社者のラップトップ発注を優先します。在庫状況により、更新が遅延する場合があります。
+
+チームメンバーは、3 年間アクティブに使用した後、ラップトップの更新を受ける資格があります。3 年間の期間は次のとおりです。
+
+* チームメンバーが割り当てられたラップトップをアクティブに使用し始めた時点で開始（必ずしも最初に受け取ったときではない）
+* 損傷、不具合、その他の事情で交換用ラップトップが発行された場合にリセット
+* チームメンバーの雇用期間ではなく、デバイスの使用期間に基づく
+
+ラップトップが必要を満たしている場合、Apple から最新の macOS バージョンが提供されなくなるまで（およそ 5 年間）、そのラップトップを使い続けることを選択できます。
+
+ラップトップの更新をリクエストするには、[このテンプレート](https://gitlab.com/gitlab-com/it/end-user-services/issues/laptop-issue-tracker/-/issues/new?issuable_template=Laptop_Refresh_Upgrade) を使用してください。
+
+古いラップトップは、**交換用ラップトップを受け取ってから 2 週間以内に**[ワイプ](/handbook/security/corporate/end-user-services/laptop-management/laptop-wipe/) または [返却](/handbook/security/corporate/end-user-services/laptop-management/laptop-offboarding-returns/#laptop-returns) する必要があります。古い MacBook から新しい MacBook へファイルを直接転送するには、[AirDrop](https://support.apple.com/guide/mac-help/use-airdrop-to-send-items-to-nearby-devices) または [Google Drive](/handbook/tools-and-tips/#adding-google-drive-to-your-mac) の使用をおすすめします。
+
+> **GitLab がデバイスがポリシーに従ってワイプされていないことを発見した場合、GitLab は通知なしにリモートロック／ワイプを強制する措置を講じることがあります。**
+
+3 年間の使用後、ワイプが完了した上でチームメンバーは無償でラップトップを保持できます。チームメンバーが調査、不正行為、解雇事由のある解雇、[GitLab’s Code of Business Conduct & Ethics](https://ir.gitlab.com/governance/governance-documents/default.aspx) の違反、その他の法的またはセキュリティ関連の調査に関与している場合、無償でラップトップを保持するオプションは無効になる場合があります。[Laptop Buyback Policy](/handbook/security/corporate/end-user-services/laptop-management/laptop-offboarding-returns/#laptop-buybacks) も併せてご参照ください。
+
+## ラップトップの交換
+
+事情が変わることもありますよね。あなたのラップトップが役割に対して不十分な場合、3 年間の更新資格をまだ得ていなくても、交換ラップトップをリクエストできます。交換されたラップトップは Laptop Buyback の対象とならず、GitLab IT の判断で再利用するために返却する必要があります。
+
+交換ラップトップは、End User Services の Issue トラッカープロジェクトで [Issue を作成する](https://gitlab.com/gitlab-com/it/end-user-services/issues/laptop-issue-tracker/-/issues/new?issuable_template=Laptop_Replacement) ことでリクエストできます。Issue に交換リクエストの理由を記載してください（ラップトップが業務に不十分、新しい役割への異動など）。
+
+**交換は Issue 内で IT とマネージャーの両方からの承認が必要です。**
+
+## 例外プロセス
+
+ほとんどのラップトップ発注は、標準的な発注プロセスに該当します。ただし、ときおり発生する非標準のリクエストには、追加の手順や承認が必要となる場合があります。
+
+### スペック外のラップトップ
+
+[こちら](/handbook/security/corporate/end-user-services/laptop-management/#laptop-specs) に記載された標準仕様外のラップトップをリクエストする場合、IT が購入する前に、チームメンバーのマネージャーおよび Device Logistics チームからの承認が必要です。マネージャーが承認したら、ロジスティクスの承認のため `@gitlab-com/gl-security/corp/logistics` をタグ付けしてください。
+
+### 自己調達
+
+**適切な承認なしには GitLab は費用を負担しません**
+
+ラップトップの自己調達には IT の承認が必要です。自己調達は、ラップトップを配送できない地域にいる場合のみ利用可能です。チームメンバーがハードウェア購入の財政支援を希望する場合、GitLab は購入を促進するために資金を前払いすることができます。[Temporary Advances](https://internal.gitlab.com/handbook/finance/expenses/#team-member-expense-temporary-advances) のハンドブックページをご覧ください。現在のチームメンバーは、地元の小売業者（オンラインまたは実店舗）から 2 つの見積りを取得し、更新／交換 Issue に含めてください。
+
+承認が下りる前に、IT がラップトップの仕様と費用を確認する必要があります。作成された Issue は、資金リリースのために AP チームによって検証されます。
+
+>会社が支払いまたは払い戻しを行ったラップトップは、GitLab の所有物です。正確な [資産追跡](/handbook/finance/accounting/#fixed-asset-register-and-asset-tracking) のため、適切な Endpoint Management System を使用して登録する必要があります。
+これらは会社の所有物のため、保険を購入する必要はありません。
+
+### 追加ラップトップのリクエスト
+
+追加デバイスが必要で、業務上の正当性があり、マネージャーの承認と IT の承認がある場合、[Laptop Refresh/Upgrade テンプレート](https://gitlab.com/gitlab-com/it/end-user-services/issues/laptop-issue-tracker/-/issues/new#) を通じて追加のラップトップをリクエストできます。セカンダリデバイスが承認された場合、新品ではなくリファービッシュ品となることにご注意ください。
+
+### 個人ラップトップの使用
+
+GitLab の業務に個人ラップトップを使用することは認められていません。新規 GitLab チームメンバーが入社日にラップトップを利用できない場合、個人の macOS または Linux ラップトップを一時的に使用することは許可されています。
+
+### 記載されていないラップトップの例外
+
+記載された例外に該当しない事情、または GitLab IT がそれを必要と判断した場合は、この [テンプレート](https://gitlab.com/gitlab-com/gl-security/security-assurance/security-compliance-commercial-and-dedicated/exceptions/-/issues/new?issuable_template=exception_request) を使用して Laptop Exception を作成できます。これらのリクエストは複数部門のリーダーシップの承認が必要であり、データ漏洩の可能性があるため推奨されません。

--- a/content/handbook/security/corporate/end-user-services/laptop-management/laptop-repairs/_index.md
+++ b/content/handbook/security/corporate/end-user-services/laptop-management/laptop-repairs/_index.md
@@ -1,0 +1,22 @@
+---
+title: "ラップトップの修理"
+upstream_path: /handbook/security/corporate/end-user-services/laptop-management/laptop-repairs/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-11T00:00:00Z"
+translator: claude
+stale: false
+---
+
+**紛失や損傷が発生した場合は、ただちに IT に報告してください。**
+
+ラップトップが破損した場合は、[End User Services Issue Tracker](https://gitlab.com/gitlab-com/it/end-user-services/issues/laptop-issue-tracker/-/issues/new?issuable_template=Laptop_Repair) で Issue を作成し、何が壊れているかを記録する必要があります。GitLab IT が損傷の評価を支援し、最も有益な修理オプションについてガイダンスを提供します。
+
+## 修理オプション
+
+一部の地域では、GitLab IT が修理を実施する Apple 認定ベンダーと契約しています。GitLab IT の判断とベンダーの可用性に応じて、破損したラップトップを修理のためにベンダーへ送付する場合があります。GitLab IT チームが、お住まいの地域でベンダーサポートが利用可能かどうかを確認できます。軽微な修理やベンダーサポートが利用できない場合は、お近くの Apple 正規サービスプロバイダーへの訪問が提案されることがあります。
+
+承認の前に、Apple 正規サービスプロバイダーからの見積りや概算見積を Issue に含める必要があります。修理作業を開始する**前に**、IT とマネージャーから承認を得る必要があります。画像または PDF が許容されますが、ラップトップを識別する情報（シリアル番号、年式、メーカー、モデル）を含める必要があります。修理見積額が 1,000 米ドル未満で、短期間で完了できる場合、GitLab IT は Apple 正規サービスプロバイダーに作業を依頼することを推奨／承認することがあります。修理に 1 日以上かかる場合は、承認済み OS を使用するバックアップ用ラップトップを必ずご用意ください。
+
+修理が 1,000 米ドルを超える、もしくは修理に時間がかかりすぎる場合、GitLab IT はラップトップを交換すると判断する場合があります。その場合、交換用ラップトップが発送され、破損したラップトップは修理またはリサイクルのために回収されます。IT がラップトップの交換が必要だと判断した場合は、[交換用の Issue](https://gitlab.com/gitlab-com/it/end-user-services/issues/laptop-issue-tracker/-/issues/new?issuable_template=Laptop_Replacement) を作成し、ラップトップ修理の Issue とリンクしてください。新しいラップトップを受け取ったら、交換テンプレートのガイドラインに従ってください。
+
+破損したラップトップは [Laptop Buyback Policy](/handbook/security/corporate/end-user-services/laptop-management/laptop-offboarding-returns/#laptop-buybacks) の対象とならず、GitLab IT に返却する必要があります。破損したラップトップの代替品はわずかに使用済みのものになる場合がありますが、同じモデルのラップトップ（パフォーマンスモデルが標準モデルに置き換わることはありません）になります。

--- a/content/handbook/security/corporate/end-user-services/laptop-management/laptop-security/appleid/_index.md
+++ b/content/handbook/security/corporate/end-user-services/laptop-management/laptop-security/appleid/_index.md
@@ -1,0 +1,10 @@
+---
+title: 業務用 Apple ID
+upstream_path: /handbook/security/corporate/end-user-services/laptop-management/laptop-security/appleid/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-11T00:00:00Z"
+translator: claude
+stale: false
+---
+
+このページはプレースホルダーです。

--- a/content/handbook/security/corporate/end-user-services/laptop-management/laptop-security/backups/_index.md
+++ b/content/handbook/security/corporate/end-user-services/laptop-management/laptop-security/backups/_index.md
@@ -1,0 +1,14 @@
+---
+title: ラップトップのバックアップ
+upstream_path: /handbook/security/corporate/end-user-services/laptop-management/laptop-security/backups/
+upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
+translated_at: "2026-05-11T00:00:00Z"
+translator: claude
+stale: false
+---
+
+## 概要
+
+データをバックアップする際、チームメンバーのラップトップでは GitLab の Google Drive を使用してください。
+
+私たちのデプロイは定期的にテストされており、保管中のデータはデフォルトで暗号化されています。

--- a/translation-state/manifest.json
+++ b/translation-state/manifest.json
@@ -23579,6 +23579,76 @@
       "translated_at": "2026-05-11T00:00:00Z",
       "model": "claude-opus-4-7",
       "input_hash": "02bb33ae44cd6c699154fbab537efbeca34ec7500e174130019b5d80b059af7d"
+    },
+    "content/handbook/security/corporate/end-user-services/laptop-management/laptop-security/backups/_index.md": {
+      "path": "content/handbook/security/corporate/end-user-services/laptop-management/laptop-security/backups/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-11T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "4583c47334be45fcb19637198abf00915cbf7b9c4ecc1cbd3fe38ac031f318f0"
+    },
+    "content/handbook/security/corporate/end-user-services/laptop-management/laptop-security/appleid/_index.md": {
+      "path": "content/handbook/security/corporate/end-user-services/laptop-management/laptop-security/appleid/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-11T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "76db7b4812f17a7266e77cf5319d8fabbec57f07a67f88fdf4d8955ebe53a20d"
+    },
+    "content/handbook/security/corporate/end-user-services/laptop-management/laptop-repairs/_index.md": {
+      "path": "content/handbook/security/corporate/end-user-services/laptop-management/laptop-repairs/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-11T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "b5042a4990a3c291972e249814bb839b9ebc8f189c792d42ce53aebd45c15434"
+    },
+    "content/handbook/security/corporate/end-user-services/laptop-management/laptop-ordering/_index.md": {
+      "path": "content/handbook/security/corporate/end-user-services/laptop-management/laptop-ordering/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-11T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "7a7e2126e4c7b734b9c695fb1fe2fe4d13155c25f95eba13881f86e4385bb8e7"
+    },
+    "content/handbook/security/corporate/end-user-services/laptop-management/laptop-offboarding-returns/_index.md": {
+      "path": "content/handbook/security/corporate/end-user-services/laptop-management/laptop-offboarding-returns/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-11T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "99119e8c346ec06bb27e04529ccd7fa84cf8e23bf77199d9324ab331815f4e67"
+    },
+    "content/handbook/security/corporate/end-user-services/access-requests/_index.md": {
+      "path": "content/handbook/security/corporate/end-user-services/access-requests/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-11T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "cbee01e00b3618b215c43eb32264c21fb4e3864404e0a2342fe9025c0c8fd857"
+    },
+    "content/handbook/security/corporate/end-user-services/access-requests/frequently-asked-questions.md": {
+      "path": "content/handbook/security/corporate/end-user-services/access-requests/frequently-asked-questions.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-11T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "18eb40aeaf95e87771848c8aa276c97e8ab4ecdfd460e249857a75b7038b9c3f"
+    },
+    "content/handbook/security/corporate/end-user-services/access-requests/access-requests/_index.md": {
+      "path": "content/handbook/security/corporate/end-user-services/access-requests/access-requests/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-11T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "e0bfdcde7ee2c3a485e3ad103ca89e5ed38db481031d5a3990056c81b50e6c43"
+    },
+    "content/handbook/security/corporate/direction/_index.md": {
+      "path": "content/handbook/security/corporate/direction/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-11T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "9980293ebdaadef567088cbb887bf05ef407c9c6c7e9bbbcbed47c0d80e38691"
+    },
+    "content/handbook/security/corporate/automation/_index.md": {
+      "path": "content/handbook/security/corporate/automation/_index.md",
+      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
+      "translated_at": "2026-05-11T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "cdb3eb3310770cac3869674f5555ccc07df92d9ff456c9449a0e84b34ba9ae97"
     }
   }
 }


### PR DESCRIPTION
## Summary
- 10 ファイル翻訳追加 (`content/handbook/security/corporate/`: end-user-services/laptop-management 5 (laptop-security/backups + appleid, laptop-repairs, laptop-ordering, laptop-offboarding-returns), end-user-services/access-requests 3 (_index + faq + access-requests/_index), direction, automation)
- manifest 3547 → 3557 entries
- base = `translation/batch-2026-05-11-4` (PR #214)

## Test plan
- [x] manifest entries == content/ ファイル数 (3557)
- [x] ローカルで `hugo --renderToMemory --quiet` がエラーなく完了
- [x] フロントマター追跡フィールド付与確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * コーポレートセキュリティハンドブックに複数ページを追加。アクセスリクエストプロセス、ラップトップ管理（発注・修理・オフボーディング・セキュリティ）、および方向性に関するドキュメントが充実しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyama0/gitlab-handbook-ja/pull/215)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->