### PR TITLE
ci: PR の変更パスから自動でラベルを付ける

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -39,6 +39,7 @@ docs:
   - changed-files:
       - any-glob-to-any-file:
           - "*.md"
+          - "**/README.md"
           - "CLAUDE.md"
           - ".claude/**"
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,49 @@
+translation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "content/handbook/**"
+          - "translation-state/**"
+
+infra:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "infra/**"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/labeler.yml"
+          - ".github/dependabot.yml"
+
+hugo:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "config/**"
+          - "layouts/**"
+          - "data/**"
+          - "assets/**"
+          - "static/**"
+          - "go.mod"
+          - "go.sum"
+
+scripts:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "scripts/**"
+          - "package.json"
+          - "package-lock.json"
+          - "tsconfig.json"
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "*.md"
+          - "CLAUDE.md"
+          - ".claude/**"
+
+upstream:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "upstream"
+          - ".gitmodules"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         with:
           configuration-path: .github/labeler.yml
           sync-labels: true


### PR DESCRIPTION
## Summary
- `actions/labeler@v5` で PR の変更パスに応じて以下のラベルを自動付与
  - `translation` / `infra` / `ci` / `hugo` / `scripts` / `docs` / `upstream`
- `sync-labels: true` により、変更が消えるとラベルも自動的に外れる
- 既存の `cloudflare/no-changes` 等 (tfcmt 由来) はそのまま共存

## 動作
- トリガー: `pull_request_target` (opened / synchronize / reopened)
- 必要な権限: `pull-requests: write` のみ
- 設定: [.github/labeler.yml](.github/labeler.yml)
- ワークフロー: [.github/workflows/labeler.yml](.github/workflows/labeler.yml)

## ラベル定義
| ラベル | 反応するパス |
| --- | --- |
| `translation` | `content/handbook/**`, `translation-state/**` |
| `infra` | `infra/**` |
| `ci` | `.github/workflows/**`, `.github/labeler.yml`, `.github/dependabot.yml` |
| `hugo` | `config/**`, `layouts/**`, `data/**`, `assets/**`, `static/**`, `go.mod`, `go.sum` |
| `scripts` | `scripts/**`, `package*.json`, `tsconfig.json` |
| `docs` | `*.md`, `CLAUDE.md`, `.claude/**` |
| `upstream` | `upstream` (submodule), `.gitmodules` |

GitHub 側のラベル定義は `gh label create` で作成済み。

## Test plan
- [ ] この PR 自体に `ci` ラベルが自動で付く
- [ ] 次回の翻訳バッチ PR に `translation` ラベルが付く
- [ ] infra PR に `infra` + `cloudflare/*` が両方付く

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * プルリクエストの変更内容に基づき、翻訳・インフラ・CI・ドキュメント・スクリプト等のカテゴリラベルが自動付与されるようになりました。
  * ラベル付与を自動で実行・同期するワークフローを追加し、PRの作成／更新時に自動でラベルの適用と同期が行われます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyama0/gitlab-handbook-ja/pull/324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->