### PR TITLE
fix(ci): R2 image base URL を Hugo build に渡して本来の R2 配信を有効化

### DIFF
--- a/.github/workflows/app_deploy.yml
+++ b/.github/workflows/app_deploy.yml
@@ -60,6 +60,11 @@ jobs:
         run: hugo --minify
         env:
           HUGO_BASEURL: ${{ vars.SITE_URL }}
+          # /images/* リダイレクト先と Markdown image render hook が前置する
+          # ベース URL を R2 公開エンドポイントに上書きする。未設定だと
+          # config.yaml の default (handbook.gitlab.com) が使われ、本家への
+          # ホットリンクになってしまう。
+          HUGO_PARAMS_image_base_url: ${{ vars.PUBLIC_R2_BASE }}
 
       - name: Pagefind index (CJK-aware static site search)
         run: npx pagefind --site public


### PR DESCRIPTION
## Summary
- `params.image_base_url` の本番上書きが CI で抜けていたため、画像参照が **すべて本家 handbook.gitlab.com にホットリンク** している状態だった
- `app_deploy.yml` の Hugo build step に `HUGO_PARAMS_image_base_url=\${{ vars.PUBLIC_R2_BASE }}` を追加

## 背景・診断
1. `curl -I https://gl-handbook-ja.page/images/gitlab-cover.png` → `301 Location: https://handbook.gitlab.com/images/gitlab-cover.png`
2. CLAUDE.md には「prod は CI で R2 公開 URL に上書きする」と明記されているが、[.github/workflows/app_deploy.yml](.github/workflows/app_deploy.yml#L59-L62) には \`HUGO_BASEURL\` しか渡されていなかった
3. [infra/locals.tf:21-25](infra/locals.tf#L21-L25) で算出される R2 URL は \`PUBLIC_R2_BASE\` という GitHub Actions Variable に既に登録済み（Pages の env_vars 用と同じ値）

## 影響
- ✅ Markdown 画像（render hook 経由）が R2 URL を指すように → 本家へのホットリンク解消
- ✅ \`_redirects\` の \`/images/*\` 301 リダイレクト先も R2 になる（_redirects 出力が動作している場合）
- ⚠️ R2 には upstream の画像が同期されている前提（\`npm run upload:images\`）

## 既知の関連事項（このPR外）
- ローカルで \`hugo\` を実行しても \`public/_redirects\` が生成されないことを確認。Hugo の output format 設定との関係を要追加調査だが、本 PR のスコープ外。
- OGP 画像（\`gitlab-cover.png\`）は R2 にも upstream 由来の本家版が同期されているため、本 PR をマージしても X カードの画像は本家のロゴのまま。これは別 PR で対応予定（画像名/パスを \`/images/\` 配下から外す案）。

## Test plan
- [ ] CI Hugo Build が通る
- [ ] マージ後デプロイされたら、\`curl -I https://gl-handbook-ja.page/images/gitlab-cover.png\` の Location が **R2 (\`pub-...r2.dev\`)** に変わる
- [ ] サイト内の Markdown 画像が R2 経由で表示される（任意のページの画像 URL を確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * デプロイメントワークフローを更新し、画像の配信源を改善しました。これにより、画像の読み込みがより効率的に処理されるようになります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyama0/gitlab-handbook-ja/pull/329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->