### PR TITLE
fix(config): rename image_base_url → imageBaseUrl so env var override works

### DIFF
--- a/.github/workflows/app_deploy.yml
+++ b/.github/workflows/app_deploy.yml
@@ -64,7 +64,12 @@ jobs:
           # ベース URL を R2 公開エンドポイントに上書きする。未設定だと
           # config.yaml の default (handbook.gitlab.com) が使われ、本家への
           # ホットリンクになってしまう。
-          HUGO_PARAMS_image_base_url: ${{ vars.PUBLIC_R2_BASE }}
+          # 注: param 名は camelCase (imageBaseUrl)。`HUGO` の直後 1 文字が
+          # delimiter として推論される Hugo の仕様上、snake_case 名を
+          # `HUGO_PARAMS_xxx` で渡すと `params.xxx.yyy.zzz` にネスト解釈
+          # されて効かないため。
+          # https://gohugo.io/configuration/introduction/
+          HUGO_PARAMS_imageBaseUrl: ${{ vars.PUBLIC_R2_BASE }}
 
       - name: Pagefind index (CJK-aware static site search)
         run: npx pagefind --site public

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,12 +38,13 @@ cd infra && terraform plan / apply       # Cloudflare Pages + R2 (direct-upload 
 
 **サイドバー**: docsy が upstream のサイドバーをそのまま生成します。順序は `weight` 昇順 → タイトル昇順。新規翻訳ではアップストリームの `weight` をそのまま保持してください。セクション配下に `_index.md` の翻訳が無いとサイドバーで URL セグメントがそのまま表示されるので、セクション `_index.md` の翻訳は優先度高めです。
 
-**画像パス**: Markdown の `![alt](/images/...)` は `layouts/_markup/render-image.html` (Goldmark の image render hook) が `params.image_base_url` を前置して外部ホストへ解決します。
+**画像パス**: Markdown の `![alt](/images/...)` は `layouts/_markup/render-image.html` (Goldmark の image render hook) が `params.imageBaseUrl` を前置して外部ホストへ解決します。
 
-- **dev**: `image_base_url: "https://handbook.gitlab.com"` (config 既定値) → upstream にホットリンクしてローカルでも画像が表示される。
-- **prod**: CI で `HUGO_PARAMS_image_base_url=https://pub-xxxx.r2.dev` のように env var で R2 公開 URL を指定。R2 へは `scripts/upload-images-r2.ts` で `upstream/static/images/` から同期する。
+- **dev**: `imageBaseUrl: "https://handbook.gitlab.com"` (config 既定値) → upstream にホットリンクしてローカルでも画像が表示される。
+- **prod**: CI で `HUGO_PARAMS_imageBaseUrl=https://pub-xxxx.r2.dev` のように env var で R2 公開 URL を指定。R2 へは `scripts/upload-images-r2.ts` で `upstream/static/images/` から同期する。
+- **param 名は camelCase 必須**: Hugo の env var override は `HUGO` の直後 1 文字を区切り文字として推論する仕様 ([公式 docs](https://gohugo.io/configuration/introduction/)) のため、snake_case の param 名を `HUGO_PARAMS_image_base_url` のように `_` 区切りで渡すと `params.image.base.url` にネスト解釈されてしまい効かない。camelCase (`imageBaseUrl`) であれば `HUGO_PARAMS_imageBaseUrl` で素直に上書きされる。
 
-protocol-relative (`//foo`) や絶対 URL (`https://...`) はそのまま、相対パス (`./foo`) も leaf bundle 想定で素通し。raw HTML の `<img src="/images/...">` (29 ファイル程度に存在) は Goldmark の render hook 対象外なので書き換わらないが、`layouts/index.redirects` 経由で `_redirects` に `/images/* {image_base_url}/images/:splat 301` を出力しているので、本番 (Cloudflare Pages) では Cloudflare の Bulk Redirects が走って外部ホストへ 301 でリダイレクトされる。ローカル `hugo server` ではこの `_redirects` は使われないので生 HTML 画像はローカルでは表示されない。
+protocol-relative (`//foo`) や絶対 URL (`https://...`) はそのまま、相対パス (`./foo`) も leaf bundle 想定で素通し。raw HTML の `<img src="/images/...">` (29 ファイル程度に存在) は Goldmark の render hook 対象外なので書き換わらないが、`layouts/index.redirects` 経由で `_redirects` に `/images/* {imageBaseUrl}/images/:splat 301` を出力しているので、本番 (Cloudflare Pages) では Cloudflare の Bulk Redirects が走って外部ホストへ 301 でリダイレクトされる。ローカル `hugo server` ではこの `_redirects` は使われないので生 HTML 画像はローカルでは表示されない。
 
 **見出し ID**: Hugo/Pandoc 流の `## 見出し {#custom-id}` は Goldmark の `parser.attribute.block: true` でネイティブ対応します（remark プラグインは不要）。
 

--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -53,9 +53,16 @@ params:
   copyright: "GitLab (handbook content) / kyama0 (translation)"
   # ルート絶対パスの画像 URL (/images/...) に前置するベース URL。
   # dev: handbook.gitlab.com にホットリンクして画像表示
-  # prod: CI で HUGO_PARAMS_image_base_url=https://pub-xxxx.r2.dev に上書き
+  # prod: CI で HUGO_PARAMS_imageBaseUrl=https://pub-xxxx.r2.dev に上書き
   # (R2 へは scripts/upload-images-r2.ts で同期済み)
-  image_base_url: "https://handbook.gitlab.com"
+  #
+  # 注: Hugo の env var override は `HUGO` の直後 1 文字を区切り文字として
+  # 推論するので、`HUGO_PARAMS_xxx` 形式で snake_case の param 名
+  # (`image_base_url` 等) を上書きしようとすると `params.image.base.url`
+  # に解釈されてしまい効かない。camelCase の `imageBaseUrl` にしておく
+  # ことで `HUGO_PARAMS_imageBaseUrl` が素直に効く。
+  # https://gohugo.io/configuration/introduction/
+  imageBaseUrl: "https://handbook.gitlab.com"
   links:
     user: []
     developer: []

--- a/layouts/_markup/render-image.html
+++ b/layouts/_markup/render-image.html
@@ -7,12 +7,12 @@
    画像ファイルそのものは持っていない。
 
    このフックはルート絶対パス (/foo.png) で参照される画像 URL の前に
-   `params.image_base_url` を前置して外部ホスト (handbook.gitlab.com
+   `params.imageBaseUrl` を前置して外部ホスト (handbook.gitlab.com
    または R2) に解決させる。
 
    - 開発時:        params 未設定 → "https://handbook.gitlab.com" にフォールバック
                     (upstream にホットリンクして画像を表示)
-   - 本番ビルド時:  HUGO_PARAMS_image_base_url=https://pub-xxxx.r2.dev
+   - 本番ビルド時:  HUGO_PARAMS_imageBaseUrl=https://pub-xxxx.r2.dev
                     のように env var で R2 公開 URL を指定
                     (R2 には scripts/upload-images-r2.ts で同期済み)
 
@@ -20,7 +20,7 @@
    (./foo, ../foo) はそのまま (Hugo のデフォルト挙動)。
 */}}
 {{- $dst := .Destination -}}
-{{- $base := strings.TrimSuffix "/" (site.Params.image_base_url | default "https://handbook.gitlab.com") -}}
+{{- $base := strings.TrimSuffix "/" (site.Params.imageBaseUrl | default "https://handbook.gitlab.com") -}}
 {{- if and (hasPrefix $dst "/") (not (hasPrefix $dst "//")) -}}
   {{- $dst = printf "%s%s" $base $dst -}}
 {{- end -}}

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -6,11 +6,11 @@
 # See: https://developers.cloudflare.com/pages/configuration/redirects/
 
 # Image proxy: 翻訳済みコンテンツの /images/... (Markdown と raw HTML
-# 双方) を外部ホスト (params.image_base_url、dev は handbook.gitlab.com、
+# 双方) を外部ホスト (params.imageBaseUrl、dev は handbook.gitlab.com、
 # prod は CI で R2 公開 URL に上書き) へ 301 リダイレクト。
 # Markdown 画像は render hook が build 時に絶対 URL に書き換えるが、
 # 生 HTML <img src="/images/..."> は素通しなのでこのルールで救済。
-{{- $imageBase := strings.TrimSuffix "/" (site.Params.image_base_url | default "https://handbook.gitlab.com") }}
+{{- $imageBase := strings.TrimSuffix "/" (site.Params.imageBaseUrl | default "https://handbook.gitlab.com") }}
 /images/* {{ $imageBase }}/images/:splat 301
 
 # Please add in chronological order by removal date following https://handbook.gitlab.com/docs/development/#redirects.


### PR DESCRIPTION
## Summary
PR #329 で `HUGO_PARAMS_image_base_url` を CI に追加したが、これは **実際には Hugo に認識されておらず**、本番で画像が本家 handbook.gitlab.com にホットリンクされ続ける状態だった。原因は Hugo の env var override の delimiter 仕様による誤解釈。本 PR で param 名を camelCase に揃えて修正する。

## Root cause（Hugo 公式 docs より）

> Hugo infers the delimiter from the first character following `HUGO`. This allows for variations like `HUGOxPARAMSxAPI_KEY=abcdefgh` using any permitted delimiter.
> — https://gohugo.io/configuration/introduction/

`HUGO_PARAMS_image_base_url` の場合：
- `HUGO` の直後の `_` が delimiter として推論される
- 結果、`params` `image` `base` `url` の **4 段ネスト** に解釈される
- 上書き対象が `params.image.base.url` になってしまい、本来の `params.image_base_url` には届かない

## ローカル検証で確証を取得

```bash
# camelCase yaml + camelCase env var
$ HUGO_PARAMS_imageBaseUrl=https://test.example/r2 hugo config | grep imagebase
  imagebaseurl = 'https://test.example/r2'  # ✅ 上書き成功
```

- ビルド後の HTML (`public/docs/markdown-guide/index.html` 等) を grep し、Markdown 画像の render hook 出力が **R2 URL に書き換わっている** ことを確認

## Changes

| File | 変更 |
|---|---|
| `config/_default/config.yaml` | param 名 `image_base_url` → `imageBaseUrl` (5 行コメントで Hugo の delimiter 仕様も解説) |
| `layouts/_markup/render-image.html` | `site.Params.image_base_url` → `site.Params.imageBaseUrl` (Hugo の Params は case-insensitive だが揃える) |
| `layouts/index.redirects` | 同上 |
| `.github/workflows/app_deploy.yml` | env var 名 `HUGO_PARAMS_image_base_url` → `HUGO_PARAMS_imageBaseUrl` + 仕様コメント追加 |
| `CLAUDE.md` | 関連記述を訂正、camelCase 必須の理由を明記 |

## Test plan
- [x] `hugo config` で env var override が反映される (ローカル)
- [x] `hugo --minify` ビルドの HTML 出力で Markdown 画像が R2 URL に書き換わる (ローカル)
- [ ] CI Hugo Build が通る
- [ ] マージ後デプロイされたら、`curl -I https://gl-handbook-ja.page/images/gitlab-cover.png` の Location が **R2 (`pub-...r2.dev`)** に変わる

## Out of scope
- `_redirects` ファイルがローカルで生成されない件 (Hugo の output format 設定との関係) は依然残り、本 PR の対象外。本番では `_redirects` が機能している（curl で 301 が返るため）ので、env var が効くようになれば実害は解消される見込み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他（Chores）**
  * 画像URLの設定パラメータを標準化し、外部ホストへのイメージ配信が正しく機能するよう改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyama0/gitlab-handbook-ja/pull/330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->