### PR TITLE
fix(upload-images): also sync repo-local static/** to R2

### DIFF
--- a/scripts/upload-images-r2.ts
+++ b/scripts/upload-images-r2.ts
@@ -105,19 +105,29 @@ async function collectReferences(): Promise<Set<string>> {
 /**
  * Upload every image under the repo's own `static/` directory to R2 with
  * the same relative key. These are JA-specific assets (the OGP cover image
- * etc.) that don't live upstream. Runs first so it wins over upstream on
- * key conflicts via the HEAD-then-skip path in the upstream pass.
+ * etc.) that don't live upstream.
  *
- * No-op if the `static/` directory doesn't exist.
+ * Always upserts (no HEAD-then-skip): when the same key already exists in
+ * R2 — typically because a prior upstream pass uploaded the upstream
+ * version of the same path — we want the JA version to overwrite it.
+ * Skipping on existence would silently strand the upstream copy in R2 and
+ * defeat the "repo-local wins on conflict" contract this pass exists for.
+ * The number of repo-local assets is small (handful of OGP covers etc.),
+ * so the extra PUTs per deploy are negligible.
+ *
+ * No-op if the `static/` directory doesn't exist; non-ENOENT errors from
+ * the existence probe are re-thrown so permission issues stay visible.
  */
-async function uploadRepoStatic(): Promise<{ uploaded: number; skipped: number }> {
+async function uploadRepoStatic(): Promise<{ uploaded: number }> {
   let uploaded = 0;
-  let skipped = 0;
 
   try {
     await stat(REPO_STATIC);
-  } catch {
-    return { uploaded, skipped };
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { uploaded };
+    }
+    throw err;
   }
 
   for await (const rel of glob('**/*', { cwd: REPO_STATIC })) {
@@ -126,11 +136,6 @@ async function uploadRepoStatic(): Promise<{ uploaded: number; skipped: number }
 
     const key = rel.split(path.sep).join('/');
     const localPath = path.join(REPO_STATIC, rel);
-
-    if (await existsInR2(key)) {
-      skipped += 1;
-      continue;
-    }
 
     const body = await readFile(localPath);
     await s3.send(new PutObjectCommand({
@@ -144,12 +149,12 @@ async function uploadRepoStatic(): Promise<{ uploaded: number; skipped: number }
     uploaded += 1;
   }
 
-  return { uploaded, skipped };
+  return { uploaded };
 }
 
 async function main() {
   const repoStats = await uploadRepoStatic();
-  console.log(`repo-local static: ${repoStats.uploaded} uploaded, ${repoStats.skipped} already in R2.`);
+  console.log(`repo-local static: ${repoStats.uploaded} uploaded (upserted, no skip).`);
 
   const refs = await collectReferences();
   if (refs.size === 0) {

--- a/scripts/upload-images-r2.ts
+++ b/scripts/upload-images-r2.ts
@@ -1,16 +1,23 @@
 /**
- * Sync images referenced by translated Markdown into the R2 bucket.
+ * Sync images referenced by translated Markdown — plus any JA-only assets
+ * sitting under the repo's own `static/` — into the R2 bucket.
  *
  * Strategy:
+ * - Repo-local `static/**` (e.g. `static/images/gitlab-cover.png`) is
+ *   uploaded *first*. These are JA-specific assets (OGP cover image etc.)
+ *   that don't exist upstream. Idempotent: skipped if already in R2.
  * - Walk `content/handbook` and collect every root-absolute asset URL
  *   (e.g. `/images/foo.svg`, both `<img src>` and `![](...)`).
  * - For each unique reference, look it up under `upstream/static/<path>`
  *   and upload to R2 with key `<path>` (no leading slash). That way the
  *   public bucket URL `<base>/<path>` matches the absolute path that
  *   lives in the Markdown source — the Hugo image render hook
- *   (layouts/_markup/render-image.html) prefixes `params.image_base_url`
+ *   (layouts/_markup/render-image.html) prefixes `params.imageBaseUrl`
  *   and the URL resolves.
  * - Idempotent: HEAD-checks each key and skips uploads that already exist.
+ * - Order matters: repo-local runs before upstream-derived, so when the
+ *   same key exists in both, the JA version wins (the upstream pass
+ *   then HEAD-checks and skips).
  *
  * Env vars (infra workflow と統一されている命名):
  *   AWS_ACCESS_KEY_ID       — R2 の access key (AWS SDK が自動で読む標準名)
@@ -51,6 +58,7 @@ const s3 = new S3Client({
 
 const TRANSLATED_ROOT = path.resolve('content/handbook');
 const UPSTREAM_STATIC = path.resolve('upstream/static');
+const REPO_STATIC = path.resolve('static');
 const IMAGE_EXT = new Set(['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.avif', '.ico']);
 
 // Match `src="/..."`, `src='/...'`, `poster="/..."`, and `![alt](/...)`.
@@ -94,10 +102,58 @@ async function collectReferences(): Promise<Set<string>> {
   return refs;
 }
 
+/**
+ * Upload every image under the repo's own `static/` directory to R2 with
+ * the same relative key. These are JA-specific assets (the OGP cover image
+ * etc.) that don't live upstream. Runs first so it wins over upstream on
+ * key conflicts via the HEAD-then-skip path in the upstream pass.
+ *
+ * No-op if the `static/` directory doesn't exist.
+ */
+async function uploadRepoStatic(): Promise<{ uploaded: number; skipped: number }> {
+  let uploaded = 0;
+  let skipped = 0;
+
+  try {
+    await stat(REPO_STATIC);
+  } catch {
+    return { uploaded, skipped };
+  }
+
+  for await (const rel of glob('**/*', { cwd: REPO_STATIC })) {
+    const ext = path.extname(rel).toLowerCase();
+    if (!IMAGE_EXT.has(ext)) continue;
+
+    const key = rel.split(path.sep).join('/');
+    const localPath = path.join(REPO_STATIC, rel);
+
+    if (await existsInR2(key)) {
+      skipped += 1;
+      continue;
+    }
+
+    const body = await readFile(localPath);
+    await s3.send(new PutObjectCommand({
+      Bucket: R2_BUCKET,
+      Key: key,
+      Body: body,
+      ContentType: contentTypeFor(ext),
+      CacheControl: 'public, max-age=31536000, immutable',
+    }));
+    console.log(`uploaded (repo-local): ${key}`);
+    uploaded += 1;
+  }
+
+  return { uploaded, skipped };
+}
+
 async function main() {
+  const repoStats = await uploadRepoStatic();
+  console.log(`repo-local static: ${repoStats.uploaded} uploaded, ${repoStats.skipped} already in R2.`);
+
   const refs = await collectReferences();
   if (refs.size === 0) {
-    console.log('No image references found in translated Markdown — nothing to upload.');
+    console.log('No image references found in translated Markdown — nothing more to upload.');
     return;
   }
 
@@ -133,7 +189,7 @@ async function main() {
     uploaded += 1;
   }
 
-  console.log(`\n${uploaded} uploaded, ${skipped} already in R2, ${missing.length} missing in upstream/static.`);
+  console.log(`\nupstream refs: ${uploaded} uploaded, ${skipped} already in R2, ${missing.length} missing in upstream/static.`);
   if (missing.length > 0) {
     // upstream のマークダウン中に書かれていても upstream/static に実体が無い参照
     // （= upstream 側で元々リンク切れ。handbook.gitlab.com でも 403 で表示できない）


### PR DESCRIPTION
## Summary
R2 配信は #330 の camelCase 修正で本来の経路に復活したが、JA 独自の OGP 画像 [\`static/images/gitlab-cover.png\`](static/images/gitlab-cover.png) は R2 に未同期で、X カード画像が 404 を返している状態。\`scripts/upload-images-r2.ts\` を拡張して repo 直下の \`static/**\` も R2 同期対象に含める。

## 背景

PR #326 (OGP 画像新規配置) → PR #329 (CI に env var 追加、ただし誤り) → PR #330 (env var 名訂正で R2 配信復活) と段階的に進めてきた。本番 curl で確認：

\`\`\`
$ curl -sI https://gl-handbook-ja.page/images/gitlab-cover.png
HTTP/2 301
location: https://pub-9e6e20bc82764d6ea1250e518669b362.r2.dev/images/gitlab-cover.png  # ✅ R2 向き

$ curl -sI https://pub-9e6e20bc82764d6ea1250e518669b362.r2.dev/images/gitlab-cover.png
HTTP/1.1 404 Not Found  # ❌ R2 上に画像が無い
\`\`\`

原因: 既存の \`upload-images-r2.ts\` は \`content/handbook/**/*.md\` の画像参照だけを walk して \`upstream/static/<path>\` から R2 にアップする設計。OGP 画像は Markdown では参照されず \`config.yaml\` の \`params.images\` から参照されるだけなので、同期対象から漏れていた。

## Changes

| 変更 | 内容 |
|---|---|
| \`uploadRepoStatic()\` 関数を新規追加 | \`static/**/*.{png,jpg,...}\` を walk してそのまま R2 に upload (key は static/ からの相対パス) |
| main() の頭で呼び出し | upstream pass より先に実行 |
| ファイル冒頭の Strategy コメント更新 | 新しい挙動と「repo-local 優先」のルールを明記 |
| \`params.image_base_url\` → \`params.imageBaseUrl\` | コメント内の参照名を最新の camelCase に揃える (#330 と整合) |

## 動作

- repo-local pass: \`static/images/gitlab-cover.png\` → key \`images/gitlab-cover.png\` で R2 へ
- upstream pass (既存): \`/images/foo.png\` (Markdown 参照) → \`upstream/static/images/foo.png\` から R2 へ
- 同じ key が両方にある場合: repo-local が先に upload → upstream pass の \`existsInR2\` で skip → **JA 版が勝つ**
- idempotent: 既に R2 に存在すれば skip

## Test plan
- [x] \`tsx scripts/upload-images-r2.ts\` (env var 無し) が早期 return で動作することを確認 (syntax check)
- [ ] CI Hugo Build / Dependency Review / gitleaks が通る
- [ ] マージ → deploy 後、\`npm run upload:images\` ステップのログに \`uploaded (repo-local): images/gitlab-cover.png\` が出る
- [ ] マージ後、\`curl -I https://pub-9e6e20bc82764d6ea1250e518669b362.r2.dev/images/gitlab-cover.png\` が **200** を返す
- [ ] X の Card Validator で JA 独自の OGP 画像が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * リポジトリ直下の静的画像が R2 に先行アップロードされるように改善
  * 画像の重複アップロードをより効率的に検出・スキップ
  * アップロード処理の結果情報（件数・スキップ数など）の表示が更新

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyama0/gitlab-handbook-ja/pull/331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->