### PR TITLE
Restore design-document-header shortcode in design-documents (1/2)

### DIFF
--- a/content/handbook/engineering/architecture/design-documents/_template.md
+++ b/content/handbook/engineering/architecture/design-documents/_template.md
@@ -78,34 +78,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/username" class="text-blue-600 hover:underline">@username</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/username" class="text-blue-600 hover:underline">@username</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/product-manager" class="text-blue-600 hover:underline">@product-manager</a>, <a href="https://gitlab.com/engineering-manager" class="text-blue-600 hover:underline">@engineering-manager</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::<stage></span></td>
-<td class="px-3 py-2 border border-gray-300">yyyy-mm-dd</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 <!--

--- a/content/handbook/engineering/architecture/design-documents/activation_engine/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/activation_engine/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-01-02T17:51:22+05:30"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jmontal" class="text-blue-600 hover:underline">@jmontal</a>, <a href="https://gitlab.com/dstull" class="text-blue-600 hover:underline">@dstull</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jtucker_gl" class="text-blue-600 hover:underline">@jtucker_gl</a>, <a href="https://gitlab.com/ghosh-abhinaba" class="text-blue-600 hover:underline">@ghosh-abhinaba</a>, <a href="https://gitlab.com/jmontal" class="text-blue-600 hover:underline">@jmontal</a>, <a href="https://gitlab.com/dstull" class="text-blue-600 hover:underline">@dstull</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::growth</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-11-18</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## Summary

--- a/content/handbook/engineering/architecture/design-documents/activity_pub/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/activity_pub/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/oelmekki" class="text-blue-600 hover:underline">@oelmekki</a>, <a href="https://gitlab.com/jpcyiza" class="text-blue-600 hover:underline">@jpcyiza</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/tkuah" class="text-blue-600 hover:underline">@tkuah</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/derekferguson" class="text-blue-600 hover:underline">@derekferguson</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300">2023-09-12</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要 {#summary}

--- a/content/handbook/engineering/architecture/design-documents/ai_agent_registry/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ai_agent_registry/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-09-12T12:15:44-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/achueshev" class="text-blue-600 hover:underline">@achueshev</a>, <a href="https://gitlab.com/mikolaj_wawrzyniak" class="text-blue-600 hover:underline">@mikolaj_wawrzyniak</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::ai-powered</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-06-05</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## Summary

--- a/content/handbook/engineering/architecture/design-documents/ai_catalog/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ai_catalog/_index.md
@@ -18,34 +18,7 @@ lastmod: "2026-02-20T09:39:32+13:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/.luke" class="text-blue-600 hover:underline">@.luke</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::ai_powered</span></td>
-<td class="px-3 py-2 border border-gray-300">2026-02-12</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## Summary

--- a/content/handbook/engineering/architecture/design-documents/ai_context_abstraction_layer/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ai_context_abstraction_layer/_index.md
@@ -20,34 +20,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/dgruzd" class="text-blue-600 hover:underline">@dgruzd</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/shekharpatnaik" class="text-blue-600 hover:underline">@shekharpatnaik</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::foundations</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-09-11</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/ai_context_management/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ai_context_management/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/dmishunov" class="text-blue-600 hover:underline">@dmishunov</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jessieay" class="text-blue-600 hover:underline">@jessieay</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/bvenker" class="text-blue-600 hover:underline">@bvenker</a>, <a href="https://gitlab.com/dmishunov" class="text-blue-600 hover:underline">@dmishunov</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::data-stores</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-06-03</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 用語集

--- a/content/handbook/engineering/architecture/design-documents/ai_evaluation_consolidation/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ai_evaluation_consolidation/_index.md
@@ -21,34 +21,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/tle_gitlab" class="text-blue-600 hover:underline">@tle_gitlab</a>, <a href="https://gitlab.com/achueshev" class="text-blue-600 hover:underline">@achueshev</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/eduardobonet" class="text-blue-600 hover:underline">@eduardobonet</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/oregand" class="text-blue-600 hover:underline">@oregand</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::ai-powered</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-07-22</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/ai_gateway/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ai_gateway/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-07-12T03:44:08+00:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/reprazent" class="text-blue-600 hover:underline">@reprazent</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a>, <a href="https://gitlab.com/stanhu" class="text-blue-600 hover:underline">@stanhu</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/m_gill" class="text-blue-600 hover:underline">@m_gill</a>, <a href="https://gitlab.com/mksionek" class="text-blue-600 hover:underline">@mksionek</a>, <a href="https://gitlab.com/marin" class="text-blue-600 hover:underline">@marin</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::modelops</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-07-14</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/ai_model_selection/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ai_model_selection/_index.md
@@ -21,34 +21,7 @@ lastmod: "2025-10-14T17:59:32+00:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/shekharpatnaik" class="text-blue-600 hover:underline">@shekharpatnaik</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sean_carroll" class="text-blue-600 hover:underline">@sean_carroll</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::ai-powered</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-09-11</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 背景

--- a/content/handbook/engineering/architecture/design-documents/ai_panel/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ai_panel/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-12-04T18:27:42+01:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/fredericcaplette" class="text-blue-600 hover:underline">@fredericcaplette</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ntepluhina" class="text-blue-600 hover:underline">@ntepluhina</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ai</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-11-21</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/analytics_with_siphon_data_insights_platform/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/analytics_with_siphon_data_insights_platform/_index.md
@@ -24,34 +24,7 @@ lastmod: "2025-11-03T17:49:46+01:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/arun.sori" class="text-blue-600 hover:underline">@arun.sori</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ahegyi" class="text-blue-600 hover:underline">@ahegyi</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nicholasklick" class="text-blue-600 hover:underline">@nicholasklick</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~group::platform insights</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-07-22</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 <!--

--- a/content/handbook/engineering/architecture/design-documents/approval_policies_bypass/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/approval_policies_bypass/_index.md
@@ -23,34 +23,7 @@ lastmod: "2025-12-08T12:27:56+01:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sashi_kumar" class="text-blue-600 hover:underline">@sashi_kumar</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/theoretick" class="text-blue-600 hover:underline">@theoretick</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/g.hickman" class="text-blue-600 hover:underline">@g.hickman</a>, <a href="https://gitlab.com/alan" class="text-blue-600 hover:underline">@alan</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::security risk management</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-05-13</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/autodevops_v2/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/autodevops_v2/_index.md
@@ -18,34 +18,7 @@ lastmod: "2026-02-09T20:42:10+00:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/hfyngvason" class="text-blue-600 hover:underline">@hfyngvason</a>, <a href="https://gitlab.com/furkanayhan" class="text-blue-600 hover:underline">@furkanayhan</a>, <a href="https://gitlab.com/jburnett" class="text-blue-600 hover:underline">@jburnett</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-12-12</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## はじめに

--- a/content/handbook/engineering/architecture/design-documents/autoflow/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/autoflow/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ash2k" class="text-blue-600 hover:underline">@ash2k</a>, <a href="https://gitlab.com/ntepluhina" class="text-blue-600 hover:underline">@ntepluhina</a>, <a href="https://gitlab.com/timofurrer" class="text-blue-600 hover:underline">@timofurrer</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nagyv-gitlab" class="text-blue-600 hover:underline">@nagyv-gitlab</a>, <a href="https://gitlab.com/nmezzopera" class="text-blue-600 hover:underline">@nmezzopera</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::deploy</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-02-16</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 GitLab AutoFlow を使用すると、DevSecOps ドメインオブジェクトと外部システム間の対話のワークフローをエンコードできます。

--- a/content/handbook/engineering/architecture/design-documents/automated_dependency_updates/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/automated_dependency_updates/_index.md
@@ -21,34 +21,7 @@ lastmod: "2025-09-08T22:45:41-04:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/hacks4oats" class="text-blue-600 hover:underline">@hacks4oats</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mbenayoun" class="text-blue-600 hover:underline">@mbenayoun</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/connorgilbert" class="text-blue-600 hover:underline">@connorgilbert</a>, <a href="https://gitlab.com/nilieskou" class="text-blue-600 hover:underline">@nilieskou</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::application security testing</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-06-17</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/automated_query_analysis/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/automated_query_analysis/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mattkasa" class="text-blue-600 hover:underline">@mattkasa</a>, <a href="https://gitlab.com/jon_jenkins" class="text-blue-600 hover:underline">@jon_jenkins</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/DylanGriffith" class="text-blue-600 hover:underline">@DylanGriffith</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/rogerwoo" class="text-blue-600 hover:underline">@rogerwoo</a>, <a href="https://gitlab.com/alexives" class="text-blue-600 hover:underline">@alexives</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::data stores</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-02-08</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 課題のサマリー

--- a/content/handbook/engineering/architecture/design-documents/backup_and_restore/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/backup_and_restore/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-08-15T15:57:20+02:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/aakriti.gupta" class="text-blue-600 hover:underline">@aakriti.gupta</a>, <a href="https://gitlab.com/brodock" class="text-blue-600 hover:underline">@brodock</a>, <a href="https://gitlab.com/ibaum" class="text-blue-600 hover:underline">@ibaum</a>, <a href="https://gitlab.com/kyetter" class="text-blue-600 hover:underline">@kyetter</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::systems</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-06-04</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/batched_background_operations/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/batched_background_operations/_index.md
@@ -21,34 +21,7 @@ lastmod: "2026-01-28T13:52:51+01:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/praba.m7n" class="text-blue-600 hover:underline">@praba.m7n</a>, <a href="https://gitlab.com/morefice" class="text-blue-600 hover:underline">@morefice</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/DylanGriffith" class="text-blue-600 hover:underline">@DylanGriffith</a>, <a href="https://gitlab.com/ahegyi" class="text-blue-600 hover:underline">@ahegyi</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/alexives" class="text-blue-600 hover:underline">@alexives</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::data access</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-07-16</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/bundle_uri/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/bundle_uri/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/toon" class="text-blue-600 hover:underline">@toon</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/oli.campeau" class="text-blue-600 hover:underline">@oli.campeau</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::systems</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-08-04</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/capacity_planning/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/capacity_planning/_index.md
@@ -15,34 +15,7 @@ lastmod: "2025-05-21T18:01:46+00:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/abrandl" class="text-blue-600 hover:underline">@abrandl</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/swiskow" class="text-blue-600 hover:underline">@swiskow</a>, <a href="https://gitlab.com/lmcandrew" class="text-blue-600 hover:underline">@lmcandrew</a>, <a href="https://gitlab.com/o-lluch" class="text-blue-600 hover:underline">@o-lluch</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300">2023-09-11</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/cdot_error_reporting/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/cdot_error_reporting/_index.md
@@ -19,34 +19,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/shreyasagarwal" class="text-blue-600 hover:underline">@shreyasagarwal</a>, <a href="https://gitlab.com/aish.sub" class="text-blue-600 hover:underline">@aish.sub</a>, <a href="https://gitlab.com/vshumilo" class="text-blue-600 hover:underline">@vshumilo</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ppalanikumar" class="text-blue-600 hover:underline">@ppalanikumar</a>, <a href="https://gitlab.com/jameslopez" class="text-blue-600 hover:underline">@jameslopez</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::fulfillment</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-09-02</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/cdot_namespace_provision_sync/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/cdot_namespace_provision_sync/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/bhrai" class="text-blue-600 hover:underline">@bhrai</a>, <a href="https://gitlab.com/cwiesner" class="text-blue-600 hover:underline">@cwiesner</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ppalanikumar" class="text-blue-600 hover:underline">@ppalanikumar</a>, <a href="https://gitlab.com/rhardarson" class="text-blue-600 hover:underline">@rhardarson</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::fulfillment</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-02-12</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/cdot_orders/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/cdot_orders/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/tyleramos" class="text-blue-600 hover:underline">@tyleramos</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/tgolubeva" class="text-blue-600 hover:underline">@tgolubeva</a>, <a href="https://gitlab.com/jameslopez" class="text-blue-600 hover:underline">@jameslopez</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::fulfillment</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-10-12</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/cdot_plan_managment/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/cdot_plan_managment/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-12-02T14:16:12-05:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/vshumilo" class="text-blue-600 hover:underline">@vshumilo</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/vitallium" class="text-blue-600 hover:underline">@vitallium</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/tgolubeva" class="text-blue-600 hover:underline">@tgolubeva</a>, <a href="https://gitlab.com/jameslopez" class="text-blue-600 hover:underline">@jameslopez</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::fulfillment</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-02-07</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/cells/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/_index.md
@@ -18,34 +18,7 @@ lastmod: "2026-02-20T16:22:14+13:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a>, <a href="https://gitlab.com/fzimmer" class="text-blue-600 hover:underline">@fzimmer</a>, <a href="https://gitlab.com/DylanGriffith" class="text-blue-600 hover:underline">@DylanGriffith</a>, <a href="https://gitlab.com/lohrc" class="text-blue-600 hover:underline">@lohrc</a>, <a href="https://gitlab.com/tkuah" class="text-blue-600 hover:underline">@tkuah</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a>, <a href="https://gitlab.com/sxuereb" class="text-blue-600 hover:underline">@sxuereb</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/daveyleach" class="text-blue-600 hover:underline">@daveyleach</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::tenant scale</span></td>
-<td class="px-3 py-2 border border-gray-300">2022-09-07</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このドキュメントは作業中であり、Cells の設計のごく初期の状態を表しています。重要な部分の多くがまだ文書化されていませんが、今後追記していく予定です。

--- a/content/handbook/engineering/architecture/design-documents/cells/container_registry_routing_service.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/container_registry_routing_service.md
@@ -13,34 +13,7 @@ lastmod: "2025-10-14T17:59:32+00:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">accepted</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300">2025-07-17</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このドキュメントは、Container Registry Routing Service の設計目標とアーキテクチャを概説します。

--- a/content/handbook/engineering/architecture/design-documents/cells/decisions/015_spanner_multiregional.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/decisions/015_spanner_multiregional.md
@@ -16,34 +16,7 @@ lastmod: "2025-08-04T09:37:20+02:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/a_richter" class="text-blue-600 hover:underline">@a_richter</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::tenant-scale</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-05-08</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 Cells アーキテクチャの Topology Service には、強力な整合性保証を持つ高可用性データベースが必要です。Cloud Spanner は[リージョナル](https://cloud.google.com/spanner/docs/instance-configurations#regional-configurations)構成と[マルチリージョナル](https://cloud.google.com/spanner/docs/instance-configurations#multi-region-configurations)構成の両方を提供します。

--- a/content/handbook/engineering/architecture/design-documents/cells/decisions/016_cross_cloud_dependecies.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/decisions/016_cross_cloud_dependecies.md
@@ -16,34 +16,7 @@ lastmod: "2025-07-22T15:16:00+02:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sxuereb" class="text-blue-600 hover:underline">@sxuereb</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::tenant-scale</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-07-21</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## コンテキスト

--- a/content/handbook/engineering/architecture/design-documents/cells/decisions/017_container_registry.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/decisions/017_container_registry.md
@@ -14,34 +14,7 @@ lastmod: "2025-07-29T16:36:36+02:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">accepted</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::tenant scale</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-07-29</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## コンテキスト

--- a/content/handbook/engineering/architecture/design-documents/cells/decisions/018_topology_service_transactional_behavior.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/decisions/018_topology_service_transactional_behavior.md
@@ -14,34 +14,7 @@ lastmod: "2025-08-05T09:12:12+02:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">accepted</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::tenant scale</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-08-04</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## コンテキスト

--- a/content/handbook/engineering/architecture/design-documents/cells/decisions/019_aws_primary_region_selection_for_cells.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/decisions/019_aws_primary_region_selection_for_cells.md
@@ -16,34 +16,7 @@ lastmod: "2025-08-26T15:28:39+02:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/tkhandelwal3" class="text-blue-600 hover:underline">@tkhandelwal3</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sxuereb" class="text-blue-600 hover:underline">@sxuereb</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::tenant-scale</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-05-08</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/cells/decisions/020_spanner_backup_strategy.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/decisions/020_spanner_backup_strategy.md
@@ -16,34 +16,7 @@ lastmod: "2025-09-22T23:50:41+12:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/daveyleach" class="text-blue-600 hover:underline">@daveyleach</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sxuereb" class="text-blue-600 hover:underline">@sxuereb</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::tenant-scale</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-05-09</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/cells/decisions/021_claims_in_database_transaction.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/decisions/021_claims_in_database_transaction.md
@@ -16,34 +16,7 @@ lastmod: "2025-10-13T16:57:55+02:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sxuereb" class="text-blue-600 hover:underline">@sxuereb</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::tenant-scale</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-05-09</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## コンテキスト

--- a/content/handbook/engineering/architecture/design-documents/cells/feature_flags.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/feature_flags.md
@@ -14,34 +14,7 @@ lastmod: "2025-07-02T12:41:38-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposal</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/skarbek" class="text-blue-600 hover:underline">@skarbek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/rymai" class="text-blue-600 hover:underline">@rymai</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/cells/infrastructure/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/infrastructure/_index.md
@@ -16,34 +16,7 @@ lastmod: "2026-01-23T12:25:37-06:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sxuereb" class="text-blue-600 hover:underline">@sxuereb</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 事前学習

--- a/content/handbook/engineering/architecture/design-documents/cells/infrastructure/cell_arch_tooling.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/infrastructure/cell_arch_tooling.md
@@ -17,34 +17,7 @@ lastmod: "2025-11-03T17:49:46+01:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/pguinoiseau" class="text-blue-600 hover:underline">@pguinoiseau</a>, <a href="https://gitlab.com/jcstephenson" class="text-blue-600 hover:underline">@jcstephenson</a>, <a href="https://gitlab.com/ayeung" class="text-blue-600 hover:underline">@ayeung</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sxuereb" class="text-blue-600 hover:underline">@sxuereb</a>, <a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/product-manager" class="text-blue-600 hover:underline">@product-manager</a>, <a href="https://gitlab.com/sabrams" class="text-blue-600 hover:underline">@sabrams</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::data stores</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-03-22</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/cells/infrastructure/deployments.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/infrastructure/deployments.md
@@ -16,34 +16,7 @@ lastmod: "2025-10-03T14:17:43-06:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nolith" class="text-blue-600 hover:underline">@nolith</a>, <a href="https://gitlab.com/skarbek" class="text-blue-600 hover:underline">@skarbek</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::platforms</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-01-09</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 免責事項: このブループリントはより多くのクロスファンクショナルなアライメントが必要です - **信頼度レベル:** 低

--- a/content/handbook/engineering/architecture/design-documents/cells/infrastructure/diff-between-dedicated.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/infrastructure/diff-between-dedicated.md
@@ -15,34 +15,7 @@ lastmod: "2025-05-21T18:01:46+00:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/skarbek" class="text-blue-600 hover:underline">@skarbek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 既存の参考資料

--- a/content/handbook/engineering/architecture/design-documents/cells/infrastructure/disaster_recovery.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/infrastructure/disaster_recovery.md
@@ -13,34 +13,7 @@ lastmod: "2025-08-21T08:26:37+02:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 使用される用語

--- a/content/handbook/engineering/architecture/design-documents/cells/infrastructure/feature_flags.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/infrastructure/feature_flags.md
@@ -20,34 +20,7 @@ lastmod: "2025-08-21T08:26:37+02:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/rpereira2" class="text-blue-600 hover:underline">@rpereira2</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nolith" class="text-blue-600 hover:underline">@nolith</a>, <a href="https://gitlab.com/skarbek" class="text-blue-600 hover:underline">@skarbek</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::platforms</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-10-14</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/cells/infrastructure/managing_changes.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/infrastructure/managing_changes.md
@@ -16,34 +16,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nolith" class="text-blue-600 hover:underline">@nolith</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::platforms</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-07-16</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 私たちは Cells 環境における「変更」の正しいシーケンシングを確保する必要があります。デプロイメント、設定変更、通常のマージリクエストは、すべて正しい順序でシーケンスされ、順次適用される必要があります。重要な変更を加速するための優先順位システムが必要です。その後、このシステムはリング間での変更の伝播もできる必要があります。マージリクエストとパイプラインだけではこれらの特性を強制できません。これらはソリューションのビルディングブロックになり得ますが、コーディネーターエンジンが必要です。

--- a/content/handbook/engineering/architecture/design-documents/cells/infrastructure/networking.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/infrastructure/networking.md
@@ -16,34 +16,7 @@ lastmod: "2025-11-03T17:49:46+01:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">accepted</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sxuereb" class="text-blue-600 hover:underline">@sxuereb</a>, <a href="https://gitlab.com/tkhandelwal3" class="text-blue-600 hover:underline">@tkhandelwal3</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/tkhandelwal3" class="text-blue-600 hover:underline">@tkhandelwal3</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::platforms</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-02-21</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 事前学習資料

--- a/content/handbook/engineering/architecture/design-documents/cells/infrastructure/observability.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/infrastructure/observability.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/igorwwwwwwwwwwwwwwwwwwww" class="text-blue-600 hover:underline">@igorwwwwwwwwwwwwwwwwwwww</a>, <a href="https://gitlab.com/reprazent" class="text-blue-600 hover:underline">@reprazent</a>, <a href="https://gitlab.com/abrandl" class="text-blue-600 hover:underline">@abrandl</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nduff" class="text-blue-600 hover:underline">@nduff</a>, <a href="https://gitlab.com/stejacks-gitlab" class="text-blue-600 hover:underline">@stejacks-gitlab</a>, <a href="https://gitlab.com/abrandl" class="text-blue-600 hover:underline">@abrandl</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::platforms</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-02-02</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/cells/infrastructure/postgresql.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/infrastructure/postgresql.md
@@ -17,34 +17,7 @@ lastmod: "2025-11-03T17:49:46+01:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">wip</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/alexander-sosna" class="text-blue-600 hover:underline">@alexander-sosna</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::data_access</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-02-06</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 現在の GitLab.com アーキテクチャ

--- a/content/handbook/engineering/architecture/design-documents/cells/infrastructure/runner.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/infrastructure/runner.md
@@ -16,34 +16,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/rehab" class="text-blue-600 hover:underline">@rehab</a>, <a href="https://gitlab.com/" class="text-blue-600 hover:underline">@</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/josephburnett" class="text-blue-600 hover:underline">@josephburnett</a>, <a href="https://gitlab.com/tmaczukin" class="text-blue-600 hover:underline">@tmaczukin</a>, <a href="https://gitlab.com/amknight" class="text-blue-600 hover:underline">@amknight</a>, <a href="https://gitlab.com/skarbek" class="text-blue-600 hover:underline">@skarbek</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-07-10</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このブループリントは、セル型アーキテクチャにおける Runner サービスのアーキテクチャとロードマップについて説明します。

--- a/content/handbook/engineering/architecture/design-documents/cells/mutual_authentication_between_cell_services.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/mutual_authentication_between_cell_services.md
@@ -17,34 +17,7 @@ lastmod: "2025-06-09T13:20:04+05:30"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/daveyleach" class="text-blue-600 hover:underline">@daveyleach</a>, <a href="https://gitlab.com/tkhandelwal3" class="text-blue-600 hover:underline">@tkhandelwal3</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sxuereb" class="text-blue-600 hover:underline">@sxuereb</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/daveyleach" class="text-blue-600 hover:underline">@daveyleach</a>, <a href="https://gitlab.com/tkhandelwal3" class="text-blue-600 hover:underline">@tkhandelwal3</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::tenant scale</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-07-01</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 事前学習資料

--- a/content/handbook/engineering/architecture/design-documents/cells/proposal-admin_area_setting_sychronization_in_cells.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/proposal-admin_area_setting_sychronization_in_cells.md
@@ -15,34 +15,7 @@ lastmod: "2025-06-20T08:50:59+02:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/tkuah" class="text-blue-600 hover:underline">@tkuah</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## ゴール

--- a/content/handbook/engineering/architecture/design-documents/cells/rejected/deployment-architecture.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/rejected/deployment-architecture.md
@@ -13,34 +13,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">rejected</span></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 _このブループリントは [インフラストラクチャブループリント](../infrastructure/index.md) によって取って代わられました_

--- a/content/handbook/engineering/architecture/design-documents/cells/rejected/proposal-stateless-router-with-buffering-requests.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/rejected/proposal-stateless-router-with-buffering-requests.md
@@ -13,34 +13,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">rejected</span></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 _このプロポーザルは [ルーティングサービスのプロポーザル](../http_routing_service.md) によって取って代わられました_

--- a/content/handbook/engineering/architecture/design-documents/cells/rejected/proposal-stateless-router-with-routes-learning.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/rejected/proposal-stateless-router-with-routes-learning.md
@@ -13,34 +13,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">rejected</span></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 _このプロポーザルは [ルーティングサービスのプロポーザル](../http_routing_service.md) によって取って代わられました_

--- a/content/handbook/engineering/architecture/design-documents/cells/ssh_routing_service.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/ssh_routing_service.md
@@ -17,34 +17,7 @@ lastmod: "2026-02-16T21:47:55+13:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/igor.drozdov" class="text-blue-600 hover:underline">@igor.drozdov</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sranasinghe" class="text-blue-600 hover:underline">@sranasinghe</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::create</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-02-29</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このドキュメントでは、SSH を介した Git のルーティングの設計目標とアーキテクチャを説明します。

--- a/content/handbook/engineering/architecture/design-documents/cells/topology_service_transactional_behavior.md
+++ b/content/handbook/engineering/architecture/design-documents/cells/topology_service_transactional_behavior.md
@@ -13,34 +13,7 @@ lastmod: "2026-01-09T14:49:10+01:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">accepted</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300">2025-07-02</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このドキュメントでは、Topology Service が Claims Service のトランザクション動作を実装するための設計目標とアーキテクチャを説明します。

--- a/content/handbook/engineering/architecture/design-documents/ci_build_speed/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ci_build_speed/_index.md
@@ -15,34 +15,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/gabrielengel_gl" class="text-blue-600 hover:underline">@gabrielengel_gl</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300">2024-01-12</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/ci_builds_runner_fleet_metrics/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ci_builds_runner_fleet_metrics/_index.md
@@ -18,34 +18,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/pedropombeiro" class="text-blue-600 hover:underline">@pedropombeiro</a>, <a href="https://gitlab.com/vshushlin" class="text-blue-600 hover:underline">@vshushlin</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300">2023-01-25</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 CI セクションは、GitLab の CI Builds と Runner Fleet において、オブザービリティと自動化に焦点を当てた新しい付加価値機能を構想しています。しかし、現在の PostgreSQL のデータベースアーキテクチャを使用してこれらの機能を実装し、オブザービリティ・自動化・AI 最適化のプロダクトビジョンを実現することは非常に困難です。その理由は以下のとおりです:

--- a/content/handbook/engineering/architecture/design-documents/ci_data_decay/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ci_data_decay/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-03-06T17:19:12+00:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a>, <a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jporter" class="text-blue-600 hover:underline">@jporter</a>, <a href="https://gitlab.com/cheryl.li" class="text-blue-600 hover:underline">@cheryl.li</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2021-09-10</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/ci_data_decay/pipeline_archival.md
+++ b/content/handbook/engineering/architecture/design-documents/ci_data_decay/pipeline_archival.md
@@ -16,34 +16,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a>, <a href="https://gitlab.com/mbobin" class="text-blue-600 hover:underline">@mbobin</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a>, <a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jreporter" class="text-blue-600 hover:underline">@jreporter</a>, <a href="https://gitlab.com/cheryl.li" class="text-blue-600 hover:underline">@cheryl.li</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-05-27</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 解決すべき問題

--- a/content/handbook/engineering/architecture/design-documents/ci_data_decay/pipeline_partitioning.md
+++ b/content/handbook/engineering/architecture/design-documents/ci_data_decay/pipeline_partitioning.md
@@ -16,34 +16,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a>, <a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jreporter" class="text-blue-600 hover:underline">@jreporter</a>, <a href="https://gitlab.com/cheryl.li" class="text-blue-600 hover:underline">@cheryl.li</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2022-05-31</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## コンテキスト

--- a/content/handbook/engineering/architecture/design-documents/ci_data_decay/reduce_data_growth_rate.md
+++ b/content/handbook/engineering/architecture/design-documents/ci_data_decay/reduce_data_growth_rate.md
@@ -16,34 +16,7 @@ lastmod: "2025-11-27T20:17:50+00:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a>, <a href="https://gitlab.com/mbobin" class="text-blue-600 hover:underline">@mbobin</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a>, <a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jreporter" class="text-blue-600 hover:underline">@jreporter</a>, <a href="https://gitlab.com/cheryl.li" class="text-blue-600 hover:underline">@cheryl.li</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-05-27</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 解決すべき問題

--- a/content/handbook/engineering/architecture/design-documents/ci_data_decay/retention_policies.md
+++ b/content/handbook/engineering/architecture/design-documents/ci_data_decay/retention_policies.md
@@ -16,34 +16,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a>, <a href="https://gitlab.com/mbobin" class="text-blue-600 hover:underline">@mbobin</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a>, <a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jreporter" class="text-blue-600 hover:underline">@jreporter</a>, <a href="https://gitlab.com/cheryl.li" class="text-blue-600 hover:underline">@cheryl.li</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-05-27</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 解決すべき問題

--- a/content/handbook/engineering/architecture/design-documents/ci_gcp_secrets_manager/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ci_gcp_secrets_manager/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/alberts-gitlab" class="text-blue-600 hover:underline">@alberts-gitlab</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jocelynjane" class="text-blue-600 hover:underline">@jocelynjane</a>, <a href="https://gitlab.com/shampton" class="text-blue-600 hover:underline">@shampton</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-11-29</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/ci_job_token/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ci_job_token/_index.md
@@ -18,34 +18,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 
 <!-- vale gitlab.FutureTense = NO -->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/alexbuijs" class="text-blue-600 hover:underline">@alexbuijs</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a>, <a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jrandazzo" class="text-blue-600 hover:underline">@jrandazzo</a>, <a href="https://gitlab.com/jayswain" class="text-blue-600 hover:underline">@jayswain</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~govern::authorization</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-08-08</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/ci_pipeline_components/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ci_pipeline_components/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a>, <a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a>, <a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a>, <a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/dhershkovitch" class="text-blue-600 hover:underline">@dhershkovitch</a>, <a href="https://gitlab.com/marknuzzo" class="text-blue-600 hover:underline">@marknuzzo</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2022-09-14</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/ci_pipeline_processing/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ci_pipeline_processing/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/furkanayhan" class="text-blue-600 hover:underline">@furkanayhan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jreporter" class="text-blue-600 hover:underline">@jreporter</a>, <a href="https://gitlab.com/cheryl.li" class="text-blue-600 hover:underline">@cheryl.li</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-05-15</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/ci_pipelines_for_github/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ci_pipelines_for_github/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mfanGitLab" class="text-blue-600 hover:underline">@mfanGitLab</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/allison.browne" class="text-blue-600 hover:underline">@allison.browne</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/rutshah" class="text-blue-600 hover:underline">@rutshah</a>, <a href="https://gitlab.com/carolinesimpson" class="text-blue-600 hover:underline">@carolinesimpson</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-11-26</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/ci_scale/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ci_scale/_index.md
@@ -16,34 +16,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/cheryl.li" class="text-blue-600 hover:underline">@cheryl.li</a>, <a href="https://gitlab.com/jreporter" class="text-blue-600 hover:underline">@jreporter</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2021-01-21</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/clickhouse_ingestion_pipeline/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/clickhouse_ingestion_pipeline/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ankitbhatnagar" class="text-blue-600 hover:underline">@ankitbhatnagar</a>, <a href="https://gitlab.com/ahegyi" class="text-blue-600 hover:underline">@ahegyi</a>, <a href="https://gitlab.com/mikolaj_wawrzyniak" class="text-blue-600 hover:underline">@mikolaj_wawrzyniak</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nhxnguyen" class="text-blue-600 hover:underline">@nhxnguyen</a>, <a href="https://gitlab.com/stkerr" class="text-blue-600 hover:underline">@stkerr</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~workinggroup::clickhouse</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-01-10</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 目次

--- a/content/handbook/engineering/architecture/design-documents/clickhouse_read_abstraction_layer/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/clickhouse_read_abstraction_layer/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mikolaj_wawrzyniak" class="text-blue-600 hover:underline">@mikolaj_wawrzyniak</a>, <a href="https://gitlab.com/jdrpereira" class="text-blue-600 hover:underline">@jdrpereira</a>, <a href="https://gitlab.com/pskorupa" class="text-blue-600 hover:underline">@pskorupa</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/DylanGriffith" class="text-blue-600 hover:underline">@DylanGriffith</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nhxnguyen" class="text-blue-600 hover:underline">@nhxnguyen</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~workinggroup::clickhouse</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-02-23</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 目次

--- a/content/handbook/engineering/architecture/design-documents/clickhouse_usage/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/clickhouse_usage/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nhxnguyen" class="text-blue-600 hover:underline">@nhxnguyen</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/dorrino" class="text-blue-600 hover:underline">@dorrino</a>, <a href="https://gitlab.com/nhxnguyen" class="text-blue-600 hover:underline">@nhxnguyen</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::data stores</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-02-02</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/cloud-native-development/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/cloud-native-development/_index.md
@@ -22,34 +22,7 @@ lastmod: "2026-01-23T12:25:37-06:00"
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/gitlab.mschoenlaub" class="text-blue-600 hover:underline">@gitlab.mschoenlaub</a>, <a href="https://gitlab.com/kkloss" class="text-blue-600 hover:underline">@kkloss</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/splattael" class="text-blue-600 hover:underline">@splattael</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mgamea" class="text-blue-600 hover:underline">@mgamea</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::developer experience</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-11-12</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 <!--

--- a/content/handbook/engineering/architecture/design-documents/cloud-native-development/phases/1-modularization.md
+++ b/content/handbook/engineering/architecture/design-documents/cloud-native-development/phases/1-modularization.md
@@ -26,34 +26,7 @@ lastmod: "2026-01-23T12:25:37-06:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/gitlab.mschoenlaub" class="text-blue-600 hover:underline">@gitlab.mschoenlaub</a>, <a href="https://gitlab.com/kkloss" class="text-blue-600 hover:underline">@kkloss</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/splattael" class="text-blue-600 hover:underline">@splattael</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mgamea" class="text-blue-600 hover:underline">@mgamea</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::developer experience</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-11-05</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 <!--

--- a/content/handbook/engineering/architecture/design-documents/cloud-native-development/phases/2-isolation.md
+++ b/content/handbook/engineering/architecture/design-documents/cloud-native-development/phases/2-isolation.md
@@ -24,34 +24,7 @@ lastmod: "2026-02-09T20:42:10+00:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/gitlab.mschoenlaub" class="text-blue-600 hover:underline">@gitlab.mschoenlaub</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/splattael" class="text-blue-600 hover:underline">@splattael</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/kkloss" class="text-blue-600 hover:underline">@kkloss</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::developer experience</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-11-26</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 <!--

--- a/content/handbook/engineering/architecture/design-documents/cloud_native_build_logs/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/cloud_native_build_logs/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-01-23T12:25:37-06:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a>, <a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/thaoyeager" class="text-blue-600 hover:underline">@thaoyeager</a>, <a href="https://gitlab.com/darbyfrey" class="text-blue-600 hover:underline">@darbyfrey</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::release</span></td>
-<td class="px-3 py-2 border border-gray-300">2020-08-26</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 クラウドネイティブと Kubernetes の採用は、GitLab がプロジェクトを背景に企業として成長するうえで最大の追い風となる 2 つの要因のうちの一つであると認識されています。

--- a/content/handbook/engineering/architecture/design-documents/cloud_native_gitlab_pages/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/cloud_native_gitlab_pages/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-01-23T12:25:37-06:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a>, <a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ogolowinski" class="text-blue-600 hover:underline">@ogolowinski</a>, <a href="https://gitlab.com/dcroft" class="text-blue-600 hover:underline">@dcroft</a>, <a href="https://gitlab.com/vshushlin" class="text-blue-600 hover:underline">@vshushlin</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::release</span></td>
-<td class="px-3 py-2 border border-gray-300">2019-05-16</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 GitLab Pages は GitLab 製品の重要なコンポーネントです。主に静的コンテンツを配信するために使用されており、明確に定義された限られた責務を持ちます。しかし残念ながら、GitLab.com の Kubernetes 移行のブロッカーになってしまっています。

--- a/content/handbook/engineering/architecture/design-documents/cloudflare-standardization/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/cloudflare-standardization/_index.md
@@ -20,34 +20,7 @@ lastmod: "2025-10-03T14:17:43-06:00"
 <!-- vale gitlab.FutureTense = NO -->
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jcstephenson" class="text-blue-600 hover:underline">@jcstephenson</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/cmiskell" class="text-blue-600 hover:underline">@cmiskell</a>, <a href="https://gitlab.com/cfeick" class="text-blue-600 hover:underline">@cfeick</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jcstephenson" class="text-blue-600 hover:underline">@jcstephenson</a>, <a href="https://gitlab.com/sabrams" class="text-blue-600 hover:underline">@sabrams</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::platforms</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-05-20</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/code_search_with_zoekt/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/code_search_with_zoekt/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-02-02T16:25:09-08:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/dgruzd" class="text-blue-600 hover:underline">@dgruzd</a>, <a href="https://gitlab.com/DylanGriffith" class="text-blue-600 hover:underline">@DylanGriffith</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/DylanGriffith" class="text-blue-600 hover:underline">@DylanGriffith</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/changzhengliu" class="text-blue-600 hover:underline">@changzhengliu</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::foundations</span></td>
-<td class="px-3 py-2 border border-gray-300">2022-12-28</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/codebase_as_chat_context/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/codebase_as_chat_context/_index.md
@@ -20,34 +20,7 @@ lastmod: "2025-11-03T17:49:46+01:00"
 <!-- vale gitlab.FutureTense = NO -->
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/partiaga" class="text-blue-600 hover:underline">@partiaga</a>, <a href="https://gitlab.com/tgao3701908" class="text-blue-600 hover:underline">@tgao3701908</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jessieay" class="text-blue-600 hover:underline">@jessieay</a>, <a href="https://gitlab.com/dgruzd" class="text-blue-600 hover:underline">@dgruzd</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jordanjanes" class="text-blue-600 hover:underline">@jordanjanes</a>, <a href="https://gitlab.com/mnohr" class="text-blue-600 hover:underline">@mnohr</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::create</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-04-02</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/compliance-frameworks/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/compliance-frameworks/_index.md
@@ -18,34 +18,7 @@ lastmod: "2025-04-30T04:51:25-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nrosandich" class="text-blue-600 hover:underline">@nrosandich</a>, <a href="https://gitlab.com/huzaifaiftikhar1" class="text-blue-600 hover:underline">@huzaifaiftikhar1</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/theoretick" class="text-blue-600 hover:underline">@theoretick</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~govern::compliance</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-07-08</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/compliance_policy_instance_level_management/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/compliance_policy_instance_level_management/_index.md
@@ -18,34 +18,7 @@ lastmod: "2025-07-25T15:41:10+12:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nrosandich" class="text-blue-600 hover:underline">@nrosandich</a>, <a href="https://gitlab.com/alan" class="text-blue-600 hover:underline">@alan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/darbyfrey" class="text-blue-600 hover:underline">@darbyfrey</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~govern::compliance</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-04-02</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## はじめに

--- a/content/handbook/engineering/architecture/design-documents/composable_codebase_using_rails_engines/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/composable_codebase_using_rails_engines/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-01-23T15:08:44-08:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">rejected</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a>, <a href="https://gitlab.com/mkaeppler" class="text-blue-600 hover:underline">@mkaeppler</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/glopezfernandez" class="text-blue-600 hover:underline">@glopezfernandez</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::non_devops</span></td>
-<td class="px-3 py-2 border border-gray-300">2021-05-19</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 NOTE:

--- a/content/handbook/engineering/architecture/design-documents/composition_analysis_analyzers_metrics/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/composition_analysis_analyzers_metrics/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-02-09T20:42:10+00:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nilieskou" class="text-blue-600 hover:underline">@nilieskou</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mbenayoun" class="text-blue-600 hover:underline">@mbenayoun</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mbenayoun" class="text-blue-600 hover:underline">@mbenayoun</a>, <a href="https://gitlab.com/zmartins" class="text-blue-600 hover:underline">@zmartins</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::secure</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-11-01</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/consolidating_groups_and_projects/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/consolidating_groups_and_projects/_index.md
@@ -18,34 +18,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/alexpooley" class="text-blue-600 hover:underline">@alexpooley</a>, <a href="https://gitlab.com/ifarkas" class="text-blue-600 hover:underline">@ifarkas</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/m_gill" class="text-blue-600 hover:underline">@m_gill</a>, <a href="https://gitlab.com/mushakov" class="text-blue-600 hover:underline">@mushakov</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::data stores</span></td>
-<td class="px-3 py-2 border border-gray-300">2021-02-07</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 多くの機能がグループまたはプロジェクト内にのみ存在しています。グループとプロジェクトの機能の境界はかつては明確でした。しかし、グループにプロジェクトの機能を持たせたり、プロジェクトにグループの機能を持たせたりする需要が増しています。例えば、グループで Issue を持ちたい、プロジェクトでエピックを持ちたいといった要求があります。

--- a/content/handbook/engineering/architecture/design-documents/container_registry_metadata_database/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/container_registry_metadata_database/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jdrpereira" class="text-blue-600 hover:underline">@jdrpereira</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/glopezfernandez" class="text-blue-600 hover:underline">@glopezfernandez</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/trizzi" class="text-blue-600 hover:underline">@trizzi</a>, <a href="https://gitlab.com/hswimelar" class="text-blue-600 hover:underline">@hswimelar</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::package</span></td>
-<td class="px-3 py-2 border border-gray-300">2020-09-29</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## GitLab コンテナレジストリの利用状況

--- a/content/handbook/engineering/architecture/design-documents/container_registry_metadata_database_self_managed_rollout/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/container_registry_metadata_database_self_managed_rollout/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/hswimelar" class="text-blue-600 hover:underline">@hswimelar</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/trizzi" class="text-blue-600 hover:underline">@trizzi</a>, <a href="https://gitlab.com/sgoldstein" class="text-blue-600 hover:underline">@sgoldstein</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::package</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-06-09</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/container_scanning_for_registry/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/container_scanning_for_registry/_index.md
@@ -15,34 +15,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/atiwari71" class="text-blue-600 hover:underline">@atiwari71</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::secure</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-07-31</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/custom_models/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/custom_models/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sean_carroll" class="text-blue-600 hover:underline">@sean_carroll</a>, <a href="https://gitlab.com/eduardobonet" class="text-blue-600 hover:underline">@eduardobonet</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jessieay" class="text-blue-600 hover:underline">@jessieay</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/susie.bee" class="text-blue-600 hover:underline">@susie.bee</a>, <a href="https://gitlab.com/m_gill" class="text-blue-600 hover:underline">@m_gill</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::ai-powered</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-03-29</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このブループリントでは、GitLab Duo 機能のバックエンドとして、GitLab Dedicated および .com でデフォルトとして提供されている Vertex または Anthropic モデルの代替として、顧客による Mistral LLM のセルフデプロイメントのサポートを説明します。このイニシアチブはインターネット接続型およびエアギャップされた GitLab デプロイメントの両方をサポートします。

--- a/content/handbook/engineering/architecture/design-documents/custom_roles/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/custom_roles/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jarka" class="text-blue-600 hover:underline">@jarka</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/alexbuijs" class="text-blue-600 hover:underline">@alexbuijs</a>, <a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::software supply chain security</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-02-13</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/dashboard_customization_framework/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/dashboard_customization_framework/_index.md
@@ -21,34 +21,7 @@ lastmod: "2025-10-14T17:59:32+00:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jiaan" class="text-blue-600 hover:underline">@jiaan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ahegyi" class="text-blue-600 hover:underline">@ahegyi</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/lfarina8" class="text-blue-600 hover:underline">@lfarina8</a>, <a href="https://gitlab.com/nicholasklick" class="text-blue-600 hover:underline">@nicholasklick</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::analytics</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-06-16</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 <!--

--- a/content/handbook/engineering/architecture/design-documents/dashboard_layout_framework/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/dashboard_layout_framework/_index.md
@@ -21,34 +21,7 @@ lastmod: "2025-10-14T17:59:32+00:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/rob.hunt" class="text-blue-600 hover:underline">@rob.hunt</a>, <a href="https://gitlab.com/jiaan" class="text-blue-600 hover:underline">@jiaan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ahegyi" class="text-blue-600 hover:underline">@ahegyi</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/lfarina8" class="text-blue-600 hover:underline">@lfarina8</a>, <a href="https://gitlab.com/nicholasklick" class="text-blue-600 hover:underline">@nicholasklick</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::analytics</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-04-08</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 <!--

--- a/content/handbook/engineering/architecture/design-documents/data_insights_platform/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/data_insights_platform/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-03-10T11:40:11+13:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ankitbhatnagar" class="text-blue-600 hover:underline">@ankitbhatnagar</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ahegyi" class="text-blue-600 hover:underline">@ahegyi</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/dennis" class="text-blue-600 hover:underline">@dennis</a>, <a href="https://gitlab.com/nicholasklick" class="text-blue-600 hover:underline">@nicholasklick</a>, <a href="https://gitlab.com/lfarina8" class="text-blue-600 hover:underline">@lfarina8</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~group::platform insights</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-04-10</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/data_insights_platform_hierarchical_data_retrieval_optimization/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/data_insights_platform_hierarchical_data_retrieval_optimization/_index.md
@@ -22,34 +22,7 @@ lastmod: "2025-05-19T13:21:59+02:00"
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">accepted</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ahegyi" class="text-blue-600 hover:underline">@ahegyi</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ankitbhatnagar" class="text-blue-600 hover:underline">@ankitbhatnagar</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/dennis" class="text-blue-600 hover:underline">@dennis</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~group::platform insights</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-02-27</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/data_insights_platform_querying_api/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/data_insights_platform_querying_api/_index.md
@@ -21,34 +21,7 @@ lastmod: "2025-08-18T10:18:01-07:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">accepted</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/rob.hunt" class="text-blue-600 hover:underline">@rob.hunt</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ahegyi" class="text-blue-600 hover:underline">@ahegyi</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/lfarina8" class="text-blue-600 hover:underline">@lfarina8</a>, <a href="https://gitlab.com/nicholasklick" class="text-blue-600 hover:underline">@nicholasklick</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~group::platform insights</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-02-27</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/database_size_limits/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/database_size_limits/_index.md
@@ -20,34 +20,7 @@ lastmod: "2025-11-19T13:56:02-06:00"
 
 <!-- vale gitlab.FutureTense = NO -->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">accepted</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/abrandl" class="text-blue-600 hover:underline">@abrandl</a>, <a href="https://gitlab.com/tkuah" class="text-blue-600 hover:underline">@tkuah</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/alexives" class="text-blue-600 hover:underline">@alexives</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::data stores</span></td>
-<td class="px-3 py-2 border border-gray-300">2021-06-23</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このドキュメントは、GitLab.com のテーブルサイズを削減・制限するための提案です。テーブルサイズを特定の閾値（100 GB）に制限することで**測定可能な目標**を設定します。ただし、10 GB の時点で対策を講じるべきです。

--- a/content/handbook/engineering/architecture/design-documents/database_testing/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/database_testing/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/abrandl" class="text-blue-600 hover:underline">@abrandl</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/glopezfernandez" class="text-blue-600 hover:underline">@glopezfernandez</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/fabian" class="text-blue-600 hover:underline">@fabian</a>, <a href="https://gitlab.com/craig-gomes" class="text-blue-600 hover:underline">@craig-gomes</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::data stores</span></td>
-<td class="px-3 py-2 border border-gray-300">2021-02-08</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 **注意:** このブループリントは部分的に実装済みです。引き続きツールの改善を進める予定です。以下の内容は、データベーステストを開発ワークフローに組み込む以前に記述された、ブループリントの歴史的なバージョンです。

--- a/content/handbook/engineering/architecture/design-documents/database_traffic_replay/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/database_traffic_replay/_index.md
@@ -21,34 +21,7 @@ lastmod: "2025-11-03T17:49:46+01:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mattkasa" class="text-blue-600 hover:underline">@mattkasa</a>, <a href="https://gitlab.com/stomlinson" class="text-blue-600 hover:underline">@stomlinson</a>, <a href="https://gitlab.com/zbraddock" class="text-blue-600 hover:underline">@zbraddock</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/tkuah" class="text-blue-600 hover:underline">@tkuah</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/alexives" class="text-blue-600 hover:underline">@alexives</a>, <a href="https://gitlab.com/rmar1" class="text-blue-600 hover:underline">@rmar1</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::data access</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-05-07</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/dependency_scanning_analyzer/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/dependency_scanning_analyzer/_index.md
@@ -19,34 +19,7 @@ lastmod: "2026-02-23T17:17:32-05:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/hacks4oats" class="text-blue-600 hover:underline">@hacks4oats</a>, <a href="https://gitlab.com/gonzoyumo" class="text-blue-600 hover:underline">@gonzoyumo</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/johncrowley" class="text-blue-600 hover:underline">@johncrowley</a>, <a href="https://gitlab.com/thiagocsf" class="text-blue-600 hover:underline">@thiagocsf</a>, <a href="https://gitlab.com/nilieskou" class="text-blue-600 hover:underline">@nilieskou</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::application security testing</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-08-14</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 <!--

--- a/content/handbook/engineering/architecture/design-documents/dependency_scanning_engine/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/dependency_scanning_engine/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-02-23T17:17:32-05:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/gonzoyumo" class="text-blue-600 hover:underline">@gonzoyumo</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mbenayoun" class="text-blue-600 hover:underline">@mbenayoun</a>, <a href="https://gitlab.com/theoretick" class="text-blue-600 hover:underline">@theoretick</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nilieskou" class="text-blue-600 hover:underline">@nilieskou</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::application security testing</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-08-26</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/deploy-workspaces-with-ci-runner/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/deploy-workspaces-with-ci-runner/_index.md
@@ -20,34 +20,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/DylanGriffith" class="text-blue-600 hover:underline">@DylanGriffith</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">devops::create</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-12-24</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/disaster_recovery/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/disaster_recovery/_index.md
@@ -15,34 +15,7 @@ lastmod: "2025-10-24T08:43:40+02:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jarv" class="text-blue-600 hover:underline">@jarv</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300">2024-01-29</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 この設計ドキュメントは実装済みです。ディザスタリカバリの現在の状態と実装内容については以下を参照してください:

--- a/content/handbook/engineering/architecture/design-documents/duo_workflow/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/duo_workflow/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-03-25T07:59:16+00:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/DylanGriffith" class="text-blue-600 hover:underline">@DylanGriffith</a>, <a href="https://gitlab.com/mikolaj_wawrzyniak" class="text-blue-600 hover:underline">@mikolaj_wawrzyniak</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::create</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-05-17</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 実行環境

--- a/content/handbook/engineering/architecture/design-documents/duo_workflow/decisions/006_tool_approval.md
+++ b/content/handbook/engineering/architecture/design-documents/duo_workflow/decisions/006_tool_approval.md
@@ -17,34 +17,7 @@ lastmod: "2026-03-20T08:04:13-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/dbernardi" class="text-blue-600 hover:underline">@dbernardi</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/john-slaughter" class="text-blue-600 hover:underline">@john-slaughter</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::ai_powered</span></td>
-<td class="px-3 py-2 border border-gray-300">2026-01-20</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/email-ingestion/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/email-ingestion/_index.md
@@ -19,34 +19,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 <!-- vale gitlab.CurrentStatus = NO -->
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/msaleiko" class="text-blue-600 hover:underline">@msaleiko</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/stanhu" class="text-blue-600 hover:underline">@stanhu</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">devops::plan</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-06-05</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/encryption_keys_rotation/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/encryption_keys_rotation/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-11-27T20:17:50+00:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">rejected</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/rymai" class="text-blue-600 hover:underline">@rymai</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a>, <a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::tenant scale</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-12-03</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 > [!warning] 計画から除外され、新しいブループリントに統合されました

--- a/content/handbook/engineering/architecture/design-documents/epic_to_work_item_migration/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/epic_to_work_item_migration/_index.md
@@ -18,34 +18,7 @@ lastmod: "2026-02-12T10:14:57+01:00"
 
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nicolasdular" class="text-blue-600 hover:underline">@nicolasdular</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nicolasdular" class="text-blue-600 hover:underline">@nicolasdular</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::plan</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-12-16</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/epss/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/epss/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/YashaRise" class="text-blue-600 hover:underline">@YashaRise</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/theoretick" class="text-blue-600 hover:underline">@theoretick</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/johncrowley" class="text-blue-600 hover:underline">@johncrowley</a>, <a href="https://gitlab.com/tkopel" class="text-blue-600 hover:underline">@tkopel</a>, <a href="https://gitlab.com/nilieskou" class="text-blue-600 hover:underline">@nilieskou</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::secure</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-06-19</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 重要な用語については[用語集](#用語集)を参照してください。

--- a/content/handbook/engineering/architecture/design-documents/feature_flags_development/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/feature_flags_development/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/glopezfernandez" class="text-blue-600 hover:underline">@glopezfernandez</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/kencjohnston" class="text-blue-600 hover:underline">@kencjohnston</a>, <a href="https://gitlab.com/craig-gomes" class="text-blue-600 hover:underline">@craig-gomes</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::non_devops</span></td>
-<td class="px-3 py-2 border border-gray-300">2020-06-10</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 フィーチャーフラグの使用は GitLab の開発において不可欠になっています。フィーチャーフラグは変更を早期にリリースし、機能が安定してパフォーマンスに優れることを確認しながら広い対象者に安全にロールアウトするための便利な方法です。

--- a/content/handbook/engineering/architecture/design-documents/feature_flags_usage_in_dev_and_ops/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/feature_flags_usage_in_dev_and_ops/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-01-23T15:08:44-08:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/rymai" class="text-blue-600 hover:underline">@rymai</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/DylanGriffith" class="text-blue-600 hover:underline">@DylanGriffith</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::non_devops</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-11-01</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このブループリントは [開発フィーチャーフラグのアーキテクチャブループリント](../feature_flags_development/) を基盤としています。

--- a/content/handbook/engineering/architecture/design-documents/feature_gates/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/feature_gates/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-11-27T20:17:50+00:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">accepted</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mgamea" class="text-blue-600 hover:underline">@mgamea</a>, <a href="https://gitlab.com/nolith" class="text-blue-600 hover:underline">@nolith</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/amyphillips" class="text-blue-600 hover:underline">@amyphillips</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::developer experience</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-06-25</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## エグゼクティブサマリー


### PR DESCRIPTION
## Summary

400 ファイル並行レビュー（8 エージェント）で検出された最大の P0 問題を一括修正。

旧 `transform-shortcodes.ts` の負債により、`engineering/architecture/design-documents/` 配下の 217 ファイルで `{{< engineering/design-document-header >}}` ショートコードが HTML 通知ブロック + ハードコード状態テーブルに事前展開されていた状態を upstream どおりに復元。

## 対象

本 PR は **108 ファイル**（`_template.md` から `feature_gates/_index.md` まで、アルファベット順前半）。残り 108 ファイルは別 PR (2/2) で対応。CodeRabbit の 150 ファイル上限を考慮して分割しています。

## なぜ復元するか

- CLAUDE.md「ショートコードは原文と完全に同じ形のまま保持／HTML に展開しない」の規約に違反
- 展開された HTML テーブルは英語見出し（Status / Authors / Coach / DRIs / Owning Stage / Created）をハードコードしており、ローカライズの効果が打ち消されていた
- docsy-gitlab モジュール側で header partial が更新された場合に追従できない
- フロントマター（`status:`, `authors:`, `coach:`, `approvers:`, `owning-stage:`, `creation-date:`）が情報の唯一の情報源だが、HTML 内のハードコード値と二重管理状態だった

## 方法

- Python の正規表現で「通知 div + テーブルラッパー div」の一貫した HTML パターンを検出
- 各ファイルについて upstream にショートコードがあることを確認してから置換
- `complex_spdx_expression_evaluation` は upstream 側のファイルが存在しないため対象外（1 件スキップ）
- 全 216 ファイル修正、CodeRabbit 150 ファイル上限の範囲内に収めるため 2 PR に分割

## Test plan

- [x] Hugo build 成功（ローカル、216 ファイル全件適用後に確認）
- [ ] CI ビルド通過
- [ ] Codex レビュー対応（環境設定があれば）

🤖 Generated with [Claude Code](https://claude.com/claude-code)