### PR TITLE
Restore design-document-header shortcode in design-documents (2/2)

### DIFF
--- a/content/handbook/engineering/architecture/design-documents/git_data_offloading/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/git_data_offloading/_index.md
@@ -16,34 +16,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jcai-gitlab" class="text-blue-600 hover:underline">@jcai-gitlab</a>, <a href="https://gitlab.com/toon" class="text-blue-600 hover:underline">@toon</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::systems</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-05-19</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/gitaly_adaptive_concurrency_limit/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitaly_adaptive_concurrency_limit/_index.md
@@ -15,34 +15,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/qmnguyen0711" class="text-blue-600 hover:underline">@qmnguyen0711</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::enablement</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-05-30</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/gitaly_handle_upload_pack_in_http2_server/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitaly_handle_upload_pack_in_http2_server/_index.md
@@ -15,34 +15,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/qmnguyen0711" class="text-blue-600 hover:underline">@qmnguyen0711</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::enablement</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-06-15</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/gitaly_plugins/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitaly_plugins/_index.md
@@ -14,34 +14,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/samihiltunen" class="text-blue-600 hover:underline">@samihiltunen</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::enablement</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-02-01</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/gitaly_reftable_rollout/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitaly_reftable_rollout/_index.md
@@ -19,34 +19,7 @@ lastmod: "2025-09-01T10:53:30+02:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/knayakgl" class="text-blue-600 hover:underline">@knayakgl</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::systems</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-09-19</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 <!--

--- a/content/handbook/engineering/architecture/design-documents/gitaly_transaction_management/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitaly_transaction_management/_index.md
@@ -16,34 +16,7 @@ lastmod: "2025-11-12T17:30:52+13:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/samihiltunen" class="text-blue-600 hover:underline">@samihiltunen</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/tkuah" class="text-blue-600 hover:underline">@tkuah</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jcaigitlab" class="text-blue-600 hover:underline">@jcaigitlab</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::enablement</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-05-30</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/gitlab_agent_deployments/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_agent_deployments/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-01-13T10:32:02+01:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/shinya.maeda" class="text-blue-600 hover:underline">@shinya.maeda</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/DylanGriffith" class="text-blue-600 hover:underline">@DylanGriffith</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nagyv-gitlab" class="text-blue-600 hover:underline">@nagyv-gitlab</a>, <a href="https://gitlab.com/cbalane" class="text-blue-600 hover:underline">@cbalane</a>, <a href="https://gitlab.com/hustewart" class="text-blue-600 hover:underline">@hustewart</a>, <a href="https://gitlab.com/hfyngvason" class="text-blue-600 hover:underline">@hfyngvason</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::deploy</span></td>
-<td class="px-3 py-2 border border-gray-300">2022-11-23</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/gitlab_cd/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_cd/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-04-21T15:27:06-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/josephburnett" class="text-blue-600 hover:underline">@josephburnett</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::deploy</span></td>
-<td class="px-3 py-2 border border-gray-300">2026-02-20</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/gitlab_cd/argo_rollouts_mvc.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_cd/argo_rollouts_mvc.md
@@ -17,34 +17,7 @@ lastmod: "2026-04-21T15:27:06-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/josephburnett" class="text-blue-600 hover:underline">@josephburnett</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::deploy</span></td>
-<td class="px-3 py-2 border border-gray-300">2026-03-25</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/gitlab_ci_events/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_ci_events/_index.md
@@ -18,34 +18,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/furkanayhan" class="text-blue-600 hover:underline">@furkanayhan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a>, <a href="https://gitlab.com/jreporter" class="text-blue-600 hover:underline">@jreporter</a>, <a href="https://gitlab.com/cheryl.li" class="text-blue-600 hover:underline">@cheryl.li</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-03-15</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/gitlab_duo_rag/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_duo_rag/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/shinya.maeda" class="text-blue-600 hover:underline">@shinya.maeda</a>, <a href="https://gitlab.com/mikolaj_wawrzyniak" class="text-blue-600 hover:underline">@mikolaj_wawrzyniak</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/stanhu" class="text-blue-600 hover:underline">@stanhu</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/pwietchner" class="text-blue-600 hover:underline">@pwietchner</a>, <a href="https://gitlab.com/oregand" class="text-blue-600 hover:underline">@oregand</a>, <a href="https://gitlab.com/tlinz" class="text-blue-600 hover:underline">@tlinz</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::ai-powered</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-01-25</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 RAG は、大規模言語モデルのトレーニングセットに存在しない知識をモデルに提供し、ユーザーの質問に答えるためにその知識を活用できるようにするアプリケーションアーキテクチャです。RAG の詳細については、[GitLab の RAG](../gitlab_rag/) を参照してください。

--- a/content/handbook/engineering/architecture/design-documents/gitlab_duo_with_amazon_q/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_duo_with_amazon_q/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sgoldstein" class="text-blue-600 hover:underline">@sgoldstein</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~section::ops</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-08-28</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 Amazon Q、GitLab Dedicated、Duo は、バンドルオファリングによって優れた開発者体験を実現するためにパートナーシップを結んでいます。

--- a/content/handbook/engineering/architecture/design-documents/gitlab_events_platform/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_events_platform/_index.md
@@ -16,34 +16,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a>, <a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jreporter" class="text-blue-600 hover:underline">@jreporter</a>, <a href="https://gitlab.com/sgoldstein" class="text-blue-600 hover:underline">@sgoldstein</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::ops section</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-03-06</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/gitlab_housekeeper/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_housekeeper/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/DylanGriffith" class="text-blue-600 hover:underline">@DylanGriffith</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/rymai" class="text-blue-600 hover:underline">@rymai</a>, <a href="https://gitlab.com/tigerwnz" class="text-blue-600 hover:underline">@tigerwnz</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::tenant scale</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-10-18</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/gitlab_knowledge_graph/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_knowledge_graph/_index.md
@@ -16,34 +16,7 @@ lastmod: "2026-02-18T15:43:02-05:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/michaelangeloio" class="text-blue-600 hover:underline">@michaelangeloio</a>, <a href="https://gitlab.com/michaelusa" class="text-blue-600 hover:underline">@michaelusa</a>, <a href="https://gitlab.com/jgdoyon1" class="text-blue-600 hover:underline">@jgdoyon1</a>, <a href="https://gitlab.com/bohdanpk" class="text-blue-600 hover:underline">@bohdanpk</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ahegyi" class="text-blue-600 hover:underline">@ahegyi</a>, <a href="https://gitlab.com/shekharpatnaik" class="text-blue-600 hover:underline">@shekharpatnaik</a>, <a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a>, <a href="https://gitlab.com/dgruzd" class="text-blue-600 hover:underline">@dgruzd</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/michaelangeloio" class="text-blue-600 hover:underline">@michaelangeloio</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::analytics</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-10-12</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/gitlab_messaging_layer/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_messaging_layer/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ankitbhatnagar" class="text-blue-600 hover:underline">@ankitbhatnagar</a>, <a href="https://gitlab.com/arun.sori" class="text-blue-600 hover:underline">@arun.sori</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/dennis" class="text-blue-600 hover:underline">@dennis</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~group::platform insights</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-02-26</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/gitlab_ml_experiments/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_ml_experiments/_index.md
@@ -14,34 +14,7 @@ lastmod: "2026-01-23T12:25:37-06:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300">2023-04-13</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このドキュメントは、GitLab 内のチームが AI、ML、データテクノロジーを活用した新しいアプリケーション機能を迅速に構築できるようにするサービス統合の簡略化された提案です。

--- a/content/handbook/engineering/architecture/design-documents/gitlab_rag/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_rag/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-11-03T17:49:46+01:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/maddievn" class="text-blue-600 hover:underline">@maddievn</a>, <a href="https://gitlab.com/mikolaj_wawrzyniak" class="text-blue-600 hover:underline">@mikolaj_wawrzyniak</a>, <a href="https://gitlab.com/dgruzd" class="text-blue-600 hover:underline">@dgruzd</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/stanhu" class="text-blue-600 hover:underline">@stanhu</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/pwietchner" class="text-blue-600 hover:underline">@pwietchner</a>, <a href="https://gitlab.com/oregand" class="text-blue-600 hover:underline">@oregand</a>, <a href="https://gitlab.com/shinya.meda" class="text-blue-600 hover:underline">@shinya.meda</a>, <a href="https://gitlab.com/mikolaj_wawrzyniak" class="text-blue-600 hover:underline">@mikolaj_wawrzyniak</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::data stores</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-02-20</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## ゴール

--- a/content/handbook/engineering/architecture/design-documents/gitlab_services/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_services/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-01-23T15:08:44-08:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nagyv-gitlab" class="text-blue-600 hover:underline">@nagyv-gitlab</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/shinya.maeda" class="text-blue-600 hover:underline">@shinya.maeda</a>, <a href="https://gitlab.com/emilybauman" class="text-blue-600 hover:underline">@emilybauman</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::deploy</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-08-18</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/gitlab_steps/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_steps/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a>, <a href="https://gitlab.com/josephburnett" class="text-blue-600 hover:underline">@josephburnett</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/dhershkovitch" class="text-blue-600 hover:underline">@dhershkovitch</a>, <a href="https://gitlab.com/DarrenEastman" class="text-blue-600 hover:underline">@DarrenEastman</a>, <a href="https://gitlab.com/cheryl.li" class="text-blue-600 hover:underline">@cheryl.li</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-08-23</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/gitlab_to_kubernetes_communication/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_to_kubernetes_communication/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ash2k" class="text-blue-600 hover:underline">@ash2k</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nicholasklick" class="text-blue-600 hover:underline">@nicholasklick</a>, <a href="https://gitlab.com/nagyv-gitlab" class="text-blue-600 hover:underline">@nagyv-gitlab</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::configure</span></td>
-<td class="px-3 py-2 border border-gray-300">2020-12-03</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このドキュメントの目的は、GitLab が GitLab エージェントを通じて Kubernetes およびクラスター内サービスとどのように通信できるかを定義することです。

--- a/content/handbook/engineering/architecture/design-documents/gitlab_translation_service/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_translation_service/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/rasamhossain" class="text-blue-600 hover:underline">@rasamhossain</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/username" class="text-blue-600 hover:underline">@username</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/product-manager" class="text-blue-600 hover:underline">@product-manager</a>, <a href="https://gitlab.com/engineering-manager" class="text-blue-600 hover:underline">@engineering-manager</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300">2024-11-08</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/gitlab_workload_identity_federation/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_workload_identity_federation/_index.md
@@ -15,34 +15,7 @@ lastmod: "2025-12-05T13:50:02+01:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/maw" class="text-blue-600 hover:underline">@maw</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::sec</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-03-21</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/gitlab_xray_rag/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/gitlab_xray_rag/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mikolaj_wawrzyniak" class="text-blue-600 hover:underline">@mikolaj_wawrzyniak</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jprovaznik" class="text-blue-600 hover:underline">@jprovaznik</a>, <a href="https://gitlab.com/maddievn" class="text-blue-600 hover:underline">@maddievn</a>, <a href="https://gitlab.com/mkaeppler" class="text-blue-600 hover:underline">@mkaeppler</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::create</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-04-23</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ~"group::global search" グループは [GitLab での RAG](../gitlab_rag/) 構築の取り組みをリードしています。これはグローバルな取り組みであるため、効率性とコラボレーションの価値観の精神から、~"group::code creation" がその取り組みに参加し、[Repository X-Ray](https://gitlab.com/gitlab-org/code-creation/repository-x-ray#repository-x-ray) データを GitLab RAG に統合することが適切です。これにより、リソースのより効率的な割り当てが実現されるだけでなく、他の AI 機能が Repository X-Ray データを統合・再利用することも可能になります。例えば、ユーザーが X-Ray レポートデータで回答できる質問を GitLab Duo Chat に投げることができます。

--- a/content/handbook/engineering/architecture/design-documents/glql/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/glql/_index.md
@@ -20,34 +20,7 @@ lastmod: "2025-07-04T13:36:56+02:00"
 <!-- vale gitlab.FutureTense = NO -->
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/himkp" class="text-blue-600 hover:underline">@himkp</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ntepluhina" class="text-blue-600 hover:underline">@ntepluhina</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/johnhope" class="text-blue-600 hover:underline">@johnhope</a>, <a href="https://gitlab.com/mmacfarlane" class="text-blue-600 hover:underline">@mmacfarlane</a>, <a href="https://gitlab.com/vshushlin" class="text-blue-600 hover:underline">@vshushlin</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::plan</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-09-25</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/google_artifact_registry_integration/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/google_artifact_registry_integration/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jdrpereira" class="text-blue-600 hover:underline">@jdrpereira</a>, <a href="https://gitlab.com/10io" class="text-blue-600 hover:underline">@10io</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/trizzi" class="text-blue-600 hover:underline">@trizzi</a>, <a href="https://gitlab.com/crystalpoole" class="text-blue-600 hover:underline">@crystalpoole</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::package</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-08-31</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/google_cloud_platform_integration/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/google_cloud_platform_integration/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sgoldstein" class="text-blue-600 hover:underline">@sgoldstein</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jessieay" class="text-blue-600 hover:underline">@jessieay</a>, <a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sgoldstein" class="text-blue-600 hover:underline">@sgoldstein</a>, <a href="https://gitlab.com/jreporter" class="text-blue-600 hover:underline">@jreporter</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~section::ops</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-10-26</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 GitLab と Google Cloud Platform（GCP）は補完的なツールを提供しており、[パートナーシップ](https://about.gitlab.com/blog/2023/08/29/gitlab-google-partnership-s3c/)を通じてインテグレーションを進めています。

--- a/content/handbook/engineering/architecture/design-documents/graphql_api/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/graphql_api/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">accepted</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a>, <a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/dsatcher" class="text-blue-600 hover:underline">@dsatcher</a>, <a href="https://gitlab.com/deuley" class="text-blue-600 hover:underline">@deuley</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::manage</span></td>
-<td class="px-3 py-2 border border-gray-300">2021-01-07</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 [GraphQL](https://graphql.org/) は API のためのデータクエリおよび操作言語であり、既存のデータでクエリを実行するためのランタイムです。

--- a/content/handbook/engineering/architecture/design-documents/group_and_project_operations_and_state_management/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/group_and_project_operations_and_state_management/_index.md
@@ -16,34 +16,7 @@ lastmod: "2026-04-08T16:19:12+02:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/lohrc" class="text-blue-600 hover:underline">@lohrc</a>, <a href="https://gitlab.com/rymai" class="text-blue-600 hover:underline">@rymai</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/lohrc" class="text-blue-600 hover:underline">@lohrc</a>, <a href="https://gitlab.com/rymai" class="text-blue-600 hover:underline">@rymai</a>, <a href="https://gitlab.com/abdwdd" class="text-blue-600 hover:underline">@abdwdd</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::runtime</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-05-26</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/image_resizing/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/image_resizing/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/craig-gomes" class="text-blue-600 hover:underline">@craig-gomes</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/timzallmann" class="text-blue-600 hover:underline">@timzallmann</a>, <a href="https://gitlab.com/joshlambert" class="text-blue-600 hover:underline">@joshlambert</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::non_devops</span></td>
-<td class="px-3 py-2 border border-gray-300">2020-10-21</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 現在、アップロードされたすべての画像を 1:1 で表示していますが、これは理想的ではありません。

--- a/content/handbook/engineering/architecture/design-documents/kev/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/kev/_index.md
@@ -18,34 +18,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/onaaman" class="text-blue-600 hover:underline">@onaaman</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/theoretick" class="text-blue-600 hover:underline">@theoretick</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/johncrowley" class="text-blue-600 hover:underline">@johncrowley</a>, <a href="https://gitlab.com/tkopel" class="text-blue-600 hover:underline">@tkopel</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::secure</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-08-11</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/labkit_configuration/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/labkit_configuration/_index.md
@@ -19,34 +19,7 @@ lastmod: "2026-03-05T09:42:34-08:00"
 <!-- vale gitlab.FutureTense = NO -->
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/stanhu" class="text-blue-600 hover:underline">@stanhu</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::systems</span></td>
-<td class="px-3 py-2 border border-gray-300">2026-03-05</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/labkit_north_star_strategy/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/labkit_north_star_strategy/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-03-16T22:50:04+13:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/e_forbes" class="text-blue-600 hover:underline">@e_forbes</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/e_forbes" class="text-blue-600 hover:underline">@e_forbes</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::developer experience</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-10-24</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 用語集

--- a/content/handbook/engineering/architecture/design-documents/license_provisioning/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/license_provisioning/_index.md
@@ -22,34 +22,7 @@ lastmod: "2026-02-27T11:49:34+01:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/M_Alvarez" class="text-blue-600 hover:underline">@M_Alvarez</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mgamea" class="text-blue-600 hover:underline">@mgamea</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::developer experience</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-10-24</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 用語集

--- a/content/handbook/engineering/architecture/design-documents/linux_patch_automation/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/linux_patch_automation/_index.md
@@ -15,34 +15,7 @@ lastmod: "2025-09-09T19:33:15-06:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mattmi" class="text-blue-600 hover:underline">@mattmi</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jarv" class="text-blue-600 hover:underline">@jarv</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300">2024-09-12</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このドキュメントは作業中であり、GitLab.com SaaS のアーキテクチャ変更を提案するものです。

--- a/content/handbook/engineering/architecture/design-documents/logging/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/logging/_index.md
@@ -15,34 +15,7 @@ lastmod: "2025-05-16T16:49:11-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/stejacks-gitlab" class="text-blue-600 hover:underline">@stejacks-gitlab</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/lmcandrew" class="text-blue-600 hover:underline">@lmcandrew</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~team::Observablity</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-07-22</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このドキュメントは、GitLab SaaS プラットフォームにおけるロギングの現状、継続的なスケールと成長に伴う課題、および次のステップに関する推奨事項を説明しています。

--- a/content/handbook/engineering/architecture/design-documents/machine_identity/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/machine_identity/_index.md
@@ -22,34 +22,7 @@ lastmod: "2025-05-05T12:20:06+02:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ifarkas" class="text-blue-600 hover:underline">@ifarkas</a>, <a href="https://gitlab.com/bdenkovych" class="text-blue-600 hover:underline">@bdenkovych</a>, <a href="https://gitlab.com/dblessing" class="text-blue-600 hover:underline">@dblessing</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/hsutor" class="text-blue-600 hover:underline">@hsutor</a>, <a href="https://gitlab.com/adil.farrukh" class="text-blue-600 hover:underline">@adil.farrukh</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">devops::software supply chain security</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-02-19</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/migrate_to_activerecord_encryption/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/migrate_to_activerecord_encryption/_index.md
@@ -22,34 +22,7 @@ lastmod: "2026-03-10T11:40:11+13:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">postponed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/boconnor" class="text-blue-600 hover:underline">@boconnor</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::runtime</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-08-29</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 > **用語の注意**

--- a/content/handbook/engineering/architecture/design-documents/mlops/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/mlops/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-11-03T17:49:46+01:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/a_akgun" class="text-blue-600 hover:underline">@a_akgun</a>, <a href="https://gitlab.com/fdegier" class="text-blue-600 hover:underline">@fdegier</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/igor.drozdov" class="text-blue-600 hover:underline">@igor.drozdov</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sean_carroll" class="text-blue-600 hover:underline">@sean_carroll</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::modelops</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-01-30</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このブループリントは、GitLab のエンドツーエンド MLOps プラットフォームアーキテクチャを説明しており、実験から本番環境へのデプロイメントまでの完全な機械学習ライフサイクルをサポートするように設計されています。このイニシアチブは、「シングルアプリケーション」哲学を維持しながら、SaaS インスタンスとセルフマネージドインスタンスの両方をサポートします。

--- a/content/handbook/engineering/architecture/design-documents/modular_monolith/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/modular_monolith/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-05-26T20:06:00+02:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a>, <a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300">2023-05-22</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/multi_platform_gateway/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/multi_platform_gateway/_index.md
@@ -19,34 +19,7 @@ lastmod: "2026-04-22T12:38:25+10:00"
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/donnaalexandra" class="text-blue-600 hover:underline">@donnaalexandra</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a>, <a href="https://gitlab.com/swiskow" class="text-blue-600 hover:underline">@swiskow</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::platforms</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-12-09</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/new_auth_stack/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/new_auth_stack/_index.md
@@ -15,34 +15,7 @@ lastmod: "2025-07-11T12:55:22+02:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/maw" class="text-blue-600 hover:underline">@maw</a>, <a href="https://gitlab.com/kamil" class="text-blue-600 hover:underline">@kamil</a>, <a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/maw" class="text-blue-600 hover:underline">@maw</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/maw" class="text-blue-600 hover:underline">@maw</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300">2025-02-17</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## サマリー

--- a/content/handbook/engineering/architecture/design-documents/notes_table_partitioning/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/notes_table_partitioning/_index.md
@@ -15,34 +15,7 @@ lastmod: "2025-08-21T08:26:37+02:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/engwan" class="text-blue-600 hover:underline">@engwan</a>, <a href="https://gitlab.com/euko" class="text-blue-600 hover:underline">@euko</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::plan</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-12-22</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 問題

--- a/content/handbook/engineering/architecture/design-documents/notifications/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/notifications/_index.md
@@ -21,34 +21,7 @@ lastmod: "2025-06-17T09:32:42+02:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">accepted</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mksionek" class="text-blue-600 hover:underline">@mksionek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jtucker_gl" class="text-blue-600 hover:underline">@jtucker_gl</a>, <a href="https://gitlab.com/samdbeckham" class="text-blue-600 hover:underline">@samdbeckham</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~group::personal productivity</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-02-25</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 <!--

--- a/content/handbook/engineering/architecture/design-documents/object_pools/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/object_pools/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-04-09T20:14:47+00:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/pks-gitlab" class="text-blue-600 hover:underline">@pks-gitlab</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::systems</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-03-30</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/object_storage/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/object_storage/_index.md
@@ -18,34 +18,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 
 <!-- vale gitlab.FutureTense = NO -->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">accepted</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nolith" class="text-blue-600 hover:underline">@nolith</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/glopezfernandez" class="text-blue-600 hover:underline">@glopezfernandez</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/marin" class="text-blue-600 hover:underline">@marin</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::data stores</span></td>
-<td class="px-3 py-2 border border-gray-300">2021-11-18</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/observability_field_standardisation/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/observability_field_standardisation/_index.md
@@ -18,34 +18,7 @@ lastmod: "2026-04-01T23:01:23+13:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/e_forbes" class="text-blue-600 hover:underline">@e_forbes</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/swiskow" class="text-blue-600 hover:underline">@swiskow</a>, <a href="https://gitlab.com/amyphillips" class="text-blue-600 hover:underline">@amyphillips</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::developer experience</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-10-15</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/observability_for_self_managed/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/observability_for_self_managed/_index.md
@@ -16,34 +16,7 @@ lastmod: "2025-09-11T14:55:05+01:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mappelman" class="text-blue-600 hover:underline">@mappelman</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sguyn" class="text-blue-600 hover:underline">@sguyn</a>, <a href="https://gitlab.com/nklick" class="text-blue-600 hover:underline">@nklick</a>, <a href="https://gitlab.com/mkaeppler" class="text-blue-600 hover:underline">@mkaeppler</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::monitor</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-09-11</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/observability_logging/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/observability_logging/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/vespian_gl" class="text-blue-600 hover:underline">@vespian_gl</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mappelman" class="text-blue-600 hover:underline">@mappelman</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sguyon" class="text-blue-600 hover:underline">@sguyon</a>, <a href="https://gitlab.com/nicholasklick" class="text-blue-600 hover:underline">@nicholasklick</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~monitor::observability</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-10-29</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/observability_metrics/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/observability_metrics/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ankitbhatnagar" class="text-blue-600 hover:underline">@ankitbhatnagar</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mappelman" class="text-blue-600 hover:underline">@mappelman</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sguyon" class="text-blue-600 hover:underline">@sguyon</a>, <a href="https://gitlab.com/nicholasklick" class="text-blue-600 hover:underline">@nicholasklick</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~monitor::observability</span></td>
-<td class="px-3 py-2 border border-gray-300">2022-11-09</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/observability_tracing/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/observability_tracing/_index.md
@@ -16,34 +16,7 @@ lastmod: "2026-01-23T15:08:44-08:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mappelman" class="text-blue-600 hover:underline">@mappelman</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/hbenson" class="text-blue-600 hover:underline">@hbenson</a>, <a href="https://gitlab.com/nicholasklick" class="text-blue-600 hover:underline">@nicholasklick</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::monitor</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-06-20</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/organization/oauth_client_auth.md
+++ b/content/handbook/engineering/architecture/design-documents/organization/oauth_client_auth.md
@@ -19,34 +19,7 @@ lastmod: "2026-03-18T16:41:45+13:00"
 
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/skundapur" class="text-blue-600 hover:underline">@skundapur</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::tenant scale</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-08-12</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/package_a_search_service_with_gitlab/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/package_a_search_service_with_gitlab/_index.md
@@ -21,34 +21,7 @@ lastmod: "2025-10-14T17:59:32+00:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/terrichu" class="text-blue-600 hover:underline">@terrichu</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/DylanGriffith" class="text-blue-600 hover:underline">@DylanGriffith</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/terrichu" class="text-blue-600 hover:underline">@terrichu</a>, <a href="https://gitlab.com/bvenker" class="text-blue-600 hover:underline">@bvenker</a>, <a href="https://gitlab.com/changzhengliu" class="text-blue-600 hover:underline">@changzhengliu</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::ai-powered</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-04-18</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 <!--

--- a/content/handbook/engineering/architecture/design-documents/package_artifact_ingestion/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/package_artifact_ingestion/_index.md
@@ -25,34 +25,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/idawson" class="text-blue-600 hover:underline">@idawson</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/" class="text-blue-600 hover:underline">@</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/idawson" class="text-blue-600 hover:underline">@idawson</a>, <a href="https://gitlab.com/gonzoyumo" class="text-blue-600 hover:underline">@gonzoyumo</a>, <a href="https://gitlab.com/dabeles" class="text-blue-600 hover:underline">@dabeles</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::application security testing</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-09-25</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 <!--

--- a/content/handbook/engineering/architecture/design-documents/permissions/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/permissions/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jessieay" class="text-blue-600 hover:underline">@jessieay</a>, <a href="https://gitlab.com/jarka" class="text-blue-600 hover:underline">@jarka</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/hsutor" class="text-blue-600 hover:underline">@hsutor</a>, <a href="https://gitlab.com/adil.farrukh" class="text-blue-600 hover:underline">@adil.farrukh</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::manage</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-03-10</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/pipeline_execution_policy/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/pipeline_execution_policy/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/Andysoiron" class="text-blue-600 hover:underline">@Andysoiron</a>, <a href="https://gitlab.com/g.hickman" class="text-blue-600 hover:underline">@g.hickman</a>, <a href="https://gitlab.com/mcavoj" class="text-blue-600 hover:underline">@mcavoj</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/g.hickman" class="text-blue-600 hover:underline">@g.hickman</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::govern</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-11-23</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このドキュメントは作成中であり、プロジェクトパイプラインの一部として CI ジョブの実行を強制し、セキュリティポリシーとコンプライアンスフレームワークを使用してそれらのジョブをプロジェクトにリンク/スコープするためのビジョンの現在の状態を表しています。

--- a/content/handbook/engineering/architecture/design-documents/pipeline_mini_graph/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/pipeline_mini_graph/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/bsandlin" class="text-blue-600 hover:underline">@bsandlin</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ntepluhina" class="text-blue-600 hover:underline">@ntepluhina</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/dhershkovitch" class="text-blue-600 hover:underline">@dhershkovitch</a>, <a href="https://gitlab.com/nmezzopera" class="text-blue-600 hover:underline">@nmezzopera</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-05-27</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このブループリントはパイプラインミニグラフの生きたドキュメントとして機能します。パイプラインミニグラフは、関連するパイプラインのステータスをユーザーに伝えるためにプラットフォーム全体のさまざまな場所で使用されています。ユーザーはコンポーネントから直接ジョブを再実行したり、さらなる調査のために特定のジョブやリンクされたパイプラインにドリルダウンすることができます。

--- a/content/handbook/engineering/architecture/design-documents/pipelines_table_redesign/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/pipelines_table_redesign/_index.md
@@ -18,34 +18,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/bsandlin" class="text-blue-600 hover:underline">@bsandlin</a>, <a href="https://gitlab.com/pburdette" class="text-blue-600 hover:underline">@pburdette</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jivanvl" class="text-blue-600 hover:underline">@jivanvl</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/bsandlin" class="text-blue-600 hover:underline">@bsandlin</a>, <a href="https://gitlab.com/pburdette" class="text-blue-600 hover:underline">@pburdette</a>, <a href="https://gitlab.com/jivanvl" class="text-blue-600 hover:underline">@jivanvl</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-04-04</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/pmdb_advisory_ingestion/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/pmdb_advisory_ingestion/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-02-09T20:42:10+00:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nilieskou" class="text-blue-600 hover:underline">@nilieskou</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ifrenkel" class="text-blue-600 hover:underline">@ifrenkel</a>, <a href="https://gitlab.com/nilieskou" class="text-blue-600 hover:underline">@nilieskou</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::secure</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-03-19</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/policies_v2/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/policies_v2/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-10-28T23:47:50+01:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/alan" class="text-blue-600 hover:underline">@alan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mcavoj" class="text-blue-600 hover:underline">@mcavoj</a>, <a href="https://gitlab.com/sashi_kumar" class="text-blue-600 hover:underline">@sashi_kumar</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/TBD" class="text-blue-600 hover:underline">@TBD</a>, <a href="https://gitlab.com/TBD" class="text-blue-600 hover:underline">@TBD</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~groups::security policies</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-09-08</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/poly_repos/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/poly_repos/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-05-13T15:09:17+01:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/stanhu" class="text-blue-600 hover:underline">@stanhu</a>, <a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a>, <a href="https://gitlab.com/shekharpatnaik" class="text-blue-600 hover:underline">@shekharpatnaik</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/TBD" class="text-blue-600 hover:underline">@TBD</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/product-manager" class="text-blue-600 hover:underline">@product-manager</a>, <a href="https://gitlab.com/engineering-manager" class="text-blue-600 hover:underline">@engineering-manager</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::&lt;stage&gt;</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-04-10</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このドキュメントは作成中であり、複数のリポジトリを含むワークフローをサポートするための計画を概説しています。これを略して「ポリリポジトリ（poly repos）」と呼びます。

--- a/content/handbook/engineering/architecture/design-documents/prep/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/prep/_index.md
@@ -19,34 +19,7 @@ lastmod: "2026-03-12T17:55:48-04:00"
 <!-- vale gitlab.FutureTense = NO -->
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/pursultani" class="text-blue-600 hover:underline">@pursultani</a>, <a href="https://gitlab.com/sarahwalker" class="text-blue-600 hover:underline">@sarahwalker</a>, <a href="https://gitlab.com/a_richter" class="text-blue-600 hover:underline">@a_richter</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/WarheadsSE" class="text-blue-600 hover:underline">@WarheadsSE</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/product-manager" class="text-blue-600 hover:underline">@product-manager</a>, <a href="https://gitlab.com/engineering-manager" class="text-blue-600 hover:underline">@engineering-manager</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::platforms</span></td>
-<td class="px-3 py-2 border border-gray-300">2026-02-19</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/prompts_migration/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/prompts_migration/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/igor.drozdov" class="text-blue-600 hover:underline">@igor.drozdov</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/shekharpatnaik" class="text-blue-600 hover:underline">@shekharpatnaik</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sean_carroll" class="text-blue-600 hover:underline">@sean_carroll</a>, <a href="https://gitlab.com/oregand" class="text-blue-600 hover:underline">@oregand</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::ai-powered</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-07-22</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/protocells/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/protocells/_index.md
@@ -16,34 +16,7 @@ lastmod: "2026-03-05T15:04:58+13:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/tkuah" class="text-blue-600 hover:underline">@tkuah</a>, <a href="https://gitlab.com/sxuereb" class="text-blue-600 hover:underline">@sxuereb</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/tkuah" class="text-blue-600 hover:underline">@tkuah</a>, <a href="https://gitlab.com/sxuereb" class="text-blue-600 hover:underline">@sxuereb</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::tenant scale</span></td>
-<td class="px-3 py-2 border border-gray-300">2026-02-15</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/rails_upgrade/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/rails_upgrade/_index.md
@@ -18,34 +18,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/igor.drozdov" class="text-blue-600 hover:underline">@igor.drozdov</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~section::dev</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-07-28</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/rapid_diffs/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/rapid_diffs/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-11-06T11:21:53+00:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/patrickbajao" class="text-blue-600 hover:underline">@patrickbajao</a>, <a href="https://gitlab.com/igor.drozdov" class="text-blue-600 hover:underline">@igor.drozdov</a>, <a href="https://gitlab.com/jerasmus" class="text-blue-600 hover:underline">@jerasmus</a>, <a href="https://gitlab.com/iamphill" class="text-blue-600 hover:underline">@iamphill</a>, <a href="https://gitlab.com/slashmanov" class="text-blue-600 hover:underline">@slashmanov</a>, <a href="https://gitlab.com/psjakubowska" class="text-blue-600 hover:underline">@psjakubowska</a>, <a href="https://gitlab.com/thomasrandolph" class="text-blue-600 hover:underline">@thomasrandolph</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ntepluhina" class="text-blue-600 hover:underline">@ntepluhina</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::create</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-10-10</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/rate_limiting/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/rate_limiting/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">accepted</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a>, <a href="https://gitlab.com/marshall007" class="text-blue-600 hover:underline">@marshall007</a>, <a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a>, <a href="https://gitlab.com/hswimelar" class="text-blue-600 hover:underline">@hswimelar</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sgoldstein" class="text-blue-600 hover:underline">@sgoldstein</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::enablement</span></td>
-<td class="px-3 py-2 border border-gray-300">2022-09-08</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/rate_limiting_simplification/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/rate_limiting_simplification/_index.md
@@ -21,34 +21,7 @@ lastmod: "2025-12-18T17:49:08+00:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/sarahwalker" class="text-blue-600 hover:underline">@sarahwalker</a>, <a href="https://gitlab.com/donnaalexandra" class="text-blue-600 hover:underline">@donnaalexandra</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/donnaalexandra" class="text-blue-600 hover:underline">@donnaalexandra</a>, <a href="https://gitlab.com/sabrams" class="text-blue-600 hover:underline">@sabrams</a>, <a href="https://gitlab.com/swiskow" class="text-blue-600 hover:underline">@swiskow</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::platforms</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-09-24</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/rate_limiting_simplification/schema.md
+++ b/content/handbook/engineering/architecture/design-documents/rate_limiting_simplification/schema.md
@@ -21,34 +21,7 @@ lastmod: "2025-06-19T14:33:54+12:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/pguinoiseau" class="text-blue-600 hover:underline">@pguinoiseau</a>, <a href="https://gitlab.com/sarahwalker" class="text-blue-600 hover:underline">@sarahwalker</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a>, <a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/pguinoiseau" class="text-blue-600 hover:underline">@pguinoiseau</a>, <a href="https://gitlab.com/sabrams" class="text-blue-600 hover:underline">@sabrams</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::platforms</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-05-16</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/rearchitect_approval_rules/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/rearchitect_approval_rules/_index.md
@@ -16,34 +16,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ghinfey" class="text-blue-600 hover:underline">@ghinfey</a>, <a href="https://gitlab.com/jtapiab" class="text-blue-600 hover:underline">@jtapiab</a>, <a href="https://gitlab.com/jwoodwardgl" class="text-blue-600 hover:underline">@jwoodwardgl</a>, <a href="https://gitlab.com/j.seto" class="text-blue-600 hover:underline">@j.seto</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::create</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-11-05</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/repository_backups/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/repository_backups/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/proglottis" class="text-blue-600 hover:underline">@proglottis</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/DylanGriffith" class="text-blue-600 hover:underline">@DylanGriffith</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::systems</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-04-26</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 <!-- For long pages, consider creating a table of contents.  The `[_TOC_]`

--- a/content/handbook/engineering/architecture/design-documents/reverse-grpc-tunnel-workspaces-and-ci/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/reverse-grpc-tunnel-workspaces-and-ci/_index.md
@@ -20,34 +20,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/DylanGriffith" class="text-blue-600 hover:underline">@DylanGriffith</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">devops::create</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-12-24</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/runner_admission_controller/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/runner_admission_controller/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ajwalker" class="text-blue-600 hover:underline">@ajwalker</a>, <a href="https://gitlab.com/johnwparent" class="text-blue-600 hover:underline">@johnwparent</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/DarrenEastman" class="text-blue-600 hover:underline">@DarrenEastman</a>, <a href="https://gitlab.com/engineering-manager" class="text-blue-600 hover:underline">@engineering-manager</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::<stage></span></td>
-<td class="px-3 py-2 border border-gray-300">2023-03-07</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 GitLab の `アドミッションコントローラー`（[Kubernetes のアドミッションコントローラーコンセプト](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/)に着想を得た）は、ジョブが永続化されるか実行のためにビルドキューに追加される前にジョブをインターセプトする提案された技術的ソリューションです。

--- a/content/handbook/engineering/architecture/design-documents/runner_job_router/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/runner_job_router/_index.md
@@ -18,34 +18,7 @@ lastmod: "2025-11-18T17:26:56+11:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/josephburnett" class="text-blue-600 hover:underline">@josephburnett</a>, <a href="https://gitlab.com/ash2k" class="text-blue-600 hover:underline">@ash2k</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ash2k" class="text-blue-600 hover:underline">@ash2k</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-09-19</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## KAS ジョブルーターモジュール設計

--- a/content/handbook/engineering/architecture/design-documents/runner_managers_kubernetes/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/runner_managers_kubernetes/_index.md
@@ -19,34 +19,7 @@ lastmod: "2026-02-05T10:00:38+00:00"
 <!-- vale gitlab.FutureTense = NO -->
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/igorwwwwwwwwwwwwwwwwwwww" class="text-blue-600 hover:underline">@igorwwwwwwwwwwwwwwwwwwww</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/josephburnett" class="text-blue-600 hover:underline">@josephburnett</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/kkyrala" class="text-blue-600 hover:underline">@kkyrala</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~team::Runners Platform</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-12-01</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## まとめ

--- a/content/handbook/engineering/architecture/design-documents/runner_scaling/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/runner_scaling/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a>, <a href="https://gitlab.com/tmaczukin" class="text-blue-600 hover:underline">@tmaczukin</a>, <a href="https://gitlab.com/josephburnett" class="text-blue-600 hover:underline">@josephburnett</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a>, <a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/DarrenEastman" class="text-blue-600 hover:underline">@DarrenEastman</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2022-01-19</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## まとめ

--- a/content/handbook/engineering/architecture/design-documents/runner_technical_vision/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/runner_technical_vision/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/josephburnett" class="text-blue-600 hover:underline">@josephburnett</a>, <a href="https://gitlab.com/ajwalker" class="text-blue-600 hover:underline">@ajwalker</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-11-05</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このドキュメントはプロダクトや機能のロードマップではなく、技術ビジョンです。GitLab Runner の問題空間を分解し、私たちが持っているプロダクトや機能、望んでいるもの、まだ考えていないものに再組み立てできる方法を説明します。

--- a/content/handbook/engineering/architecture/design-documents/runner_tokens/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/runner_tokens/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/pedropombeiro" class="text-blue-600 hover:underline">@pedropombeiro</a>, <a href="https://gitlab.com/tmaczukin" class="text-blue-600 hover:underline">@tmaczukin</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nicolewilliams" class="text-blue-600 hover:underline">@nicolewilliams</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::verify</span></td>
-<td class="px-3 py-2 border border-gray-300">2022-10-27</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## まとめ

--- a/content/handbook/engineering/architecture/design-documents/runway/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/runway/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 <!-- Blueprints often contain forward-looking statements -->
 <!-- vale gitlab.FutureTense = NO -->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/igorwwwwwwwwwwwwwwwwwwww" class="text-blue-600 hover:underline">@igorwwwwwwwwwwwwwwwwwwww</a>, <a href="https://gitlab.com/ggillies" class="text-blue-600 hover:underline">@ggillies</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/marin" class="text-blue-600 hover:underline">@marin</a>, <a href="https://gitlab.com/fzimmer" class="text-blue-600 hover:underline">@fzimmer</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300">2023-07-31</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## まとめ

--- a/content/handbook/engineering/architecture/design-documents/saas_trial_eligibility_system/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/saas_trial_eligibility_system/_index.md
@@ -19,34 +19,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/dstull" class="text-blue-600 hover:underline">@dstull</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/p_cordero" class="text-blue-600 hover:underline">@p_cordero</a>, <a href="https://gitlab.com/courtmeddaugh" class="text-blue-600 hover:underline">@courtmeddaugh</a>, <a href="https://gitlab.com/dstull" class="text-blue-600 hover:underline">@dstull</a>, <a href="https://gitlab.com/qzhaogitlab" class="text-blue-600 hover:underline">@qzhaogitlab</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::growth</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-01-24</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## まとめ

--- a/content/handbook/engineering/architecture/design-documents/sast_glas_diff_scan/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/sast_glas_diff_scan/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-10-14T17:59:32+00:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/smtan" class="text-blue-600 hover:underline">@smtan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/bwill" class="text-blue-600 hover:underline">@bwill</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/beckalippert" class="text-blue-600 hover:underline">@beckalippert</a>, <a href="https://gitlab.com/svedova" class="text-blue-600 hover:underline">@svedova</a>, <a href="https://gitlab.com/connorgilbert" class="text-blue-600 hover:underline">@connorgilbert</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::application security testing</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-05-13</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## まとめ

--- a/content/handbook/engineering/architecture/design-documents/sast_ide_integration/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/sast_ide_integration/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/erran" class="text-blue-600 hover:underline">@erran</a>, <a href="https://gitlab.com/jleasure" class="text-blue-600 hover:underline">@jleasure</a>, <a href="https://gitlab.com/julianthome" class="text-blue-600 hover:underline">@julianthome</a>, <a href="https://gitlab.com/theoretick" class="text-blue-600 hover:underline">@theoretick</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/theoretick" class="text-blue-600 hover:underline">@theoretick</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/connorgilbert" class="text-blue-600 hover:underline">@connorgilbert</a>, <a href="https://gitlab.com/dashaadu" class="text-blue-600 hover:underline">@dashaadu</a>, <a href="https://gitlab.com/tkopel" class="text-blue-600 hover:underline">@tkopel</a>, <a href="https://gitlab.com/kisha.mavryck" class="text-blue-600 hover:underline">@kisha.mavryck</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::secure</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-06-21</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## まとめ

--- a/content/handbook/engineering/architecture/design-documents/secret_detection/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/secret_detection/_index.md
@@ -18,34 +18,7 @@ lastmod: "2026-03-27T09:26:13-07:00"
 
 <!-- vale gitlab.FutureTense = NO -->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/theoretick" class="text-blue-600 hover:underline">@theoretick</a>, <a href="https://gitlab.com/vbhat161" class="text-blue-600 hover:underline">@vbhat161</a>, <a href="https://gitlab.com/ahmed.hemdan" class="text-blue-600 hover:underline">@ahmed.hemdan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/theoretick" class="text-blue-600 hover:underline">@theoretick</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/abellucci" class="text-blue-600 hover:underline">@abellucci</a>, <a href="https://gitlab.com/amarpatel" class="text-blue-600 hover:underline">@amarpatel</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::application security testing</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-12-10</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/secret_detection_validity_checks/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/secret_detection_validity_checks/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-09-09T22:00:13-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/craigmsmith, @atiwari71, @ngeorge1" class="text-blue-600 hover:underline">@craigmsmith, @atiwari71, @ngeorge1</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/theoretick" class="text-blue-600 hover:underline">@theoretick</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::secure</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-07-08</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/secret_manager/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/secret_manager/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-02-13T12:34:40+01:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/alberts-gitlab" class="text-blue-600 hover:underline">@alberts-gitlab</a>, <a href="https://gitlab.com/iamricecake" class="text-blue-600 hover:underline">@iamricecake</a>, <a href="https://gitlab.com/cipherboy-gitlab" class="text-blue-600 hover:underline">@cipherboy-gitlab</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a>, <a href="https://gitlab.com/fabiopitino" class="text-blue-600 hover:underline">@fabiopitino</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/jocelynjane" class="text-blue-600 hover:underline">@jocelynjane</a>, <a href="https://gitlab.com/shampton" class="text-blue-600 hover:underline">@shampton</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~sec::govern</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-08-07</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/security_analyzer_configuration_profiles/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/security_analyzer_configuration_profiles/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-02-11T07:39:18-08:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/theoretick" class="text-blue-600 hover:underline">@theoretick</a>, <a href="https://gitlab.com/ahmed.hemdan" class="text-blue-600 hover:underline">@ahmed.hemdan</a>, <a href="https://gitlab.com/minac" class="text-blue-600 hover:underline">@minac</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/or-gal" class="text-blue-600 hover:underline">@or-gal</a>, <a href="https://gitlab.com/g.hickman" class="text-blue-600 hover:underline">@g.hickman</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~sec::security risk management</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-10-31</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/security_inventory/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/security_inventory/_index.md
@@ -18,34 +18,7 @@ lastmod: "2025-07-09T13:01:28-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/rossfuhrman" class="text-blue-600 hover:underline">@rossfuhrman</a>, <a href="https://gitlab.com/gkatz1" class="text-blue-600 hover:underline">@gkatz1</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/theoretick" class="text-blue-600 hover:underline">@theoretick</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::security risk management</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-04-07</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/security_policies_database_read_model/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/security_policies_database_read_model/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-12-08T10:53:25+01:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mcavoj" class="text-blue-600 hover:underline">@mcavoj</a>, <a href="https://gitlab.com/sashi_kumar" class="text-blue-600 hover:underline">@sashi_kumar</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/theoretick" class="text-blue-600 hover:underline">@theoretick</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/g.hickman" class="text-blue-600 hover:underline">@g.hickman</a>, <a href="https://gitlab.com/alan" class="text-blue-600 hover:underline">@alan</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::security risk management</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-12-07</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このドキュメントは作業中であり、最適化されたポリシー更新と伝播を可能にする新しいセキュリティポリシーアーキテクチャの提案を表しています。

--- a/content/handbook/engineering/architecture/design-documents/self_hosted_finetuning/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/self_hosted_finetuning/_index.md
@@ -21,34 +21,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/enikon" class="text-blue-600 hover:underline">@enikon</a>, <a href="https://gitlab.com/bcardoso-" class="text-blue-600 hover:underline">@bcardoso-</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/eduardobonet" class="text-blue-600 hover:underline">@eduardobonet</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/susie.bee" class="text-blue-600 hover:underline">@susie.bee</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::ai-powered</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-02-03</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/selfmanaged_segmentation/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/selfmanaged_segmentation/_index.md
@@ -33,34 +33,7 @@ Document statuses you can use:
 <!-- vale gitlab.FutureTense = NO -->
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/WarheadsSE" class="text-blue-600 hover:underline">@WarheadsSE</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/WarheadsSE" class="text-blue-600 hover:underline">@WarheadsSE</a>, <a href="https://gitlab.com/mbruemmer" class="text-blue-600 hover:underline">@mbruemmer</a>, <a href="https://gitlab.com/mbursi" class="text-blue-600 hover:underline">@mbursi</a>, <a href="https://gitlab.com/nolith" class="text-blue-600 hover:underline">@nolith</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::gitlab delivery</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-06-24</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/service_catalog/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/service_catalog/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-05-16T16:49:11-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/reprazent" class="text-blue-600 hover:underline">@reprazent</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/tmillhouse" class="text-blue-600 hover:underline">@tmillhouse</a>, <a href="https://gitlab.com/lmcandrew" class="text-blue-600 hover:underline">@lmcandrew</a>, <a href="https://gitlab.com/rnienaber" class="text-blue-600 hover:underline">@rnienaber</a>, <a href="https://gitlab.com/swiskow" class="text-blue-600 hover:underline">@swiskow</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::platforms</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-07-11</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/siphon/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/siphon/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ahegyi" class="text-blue-600 hover:underline">@ahegyi</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a>, <a href="https://gitlab.com/abrandl" class="text-blue-600 hover:underline">@abrandl</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/dennis" class="text-blue-600 hover:underline">@dennis</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::monitor</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-11-20</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/slsa_level_3/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/slsa_level_3/_index.md
@@ -18,34 +18,7 @@ lastmod: "2026-02-10T07:02:10+13:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nrosandich" class="text-blue-600 hover:underline">@nrosandich</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/darbyfrey" class="text-blue-600 hover:underline">@darbyfrey</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::software supply chain security</span></td>
-<td class="px-3 py-2 border border-gray-300">2024-12-18</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/spec_driven_development/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/spec_driven_development/_index.md
@@ -21,34 +21,7 @@ lastmod: "2026-04-22T10:27:46-04:00"
 <!-- vale gitlab.FutureTense = NO -->
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/fredericcaplette" class="text-blue-600 hover:underline">@fredericcaplette</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ntepluhina" class="text-blue-600 hover:underline">@ntepluhina</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/fredericcaplette" class="text-blue-600 hover:underline">@fredericcaplette</a>, <a href="https://gitlab.com/vanessaotto" class="text-blue-600 hover:underline">@vanessaotto</a>, <a href="https://gitlab.com/marcsaleiko" class="text-blue-600 hover:underline">@marcsaleiko</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::plan</span></td>
-<td class="px-3 py-2 border border-gray-300">2026-04-16</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/ssh_certificates/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/ssh_certificates/_index.md
@@ -16,34 +16,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/igor.drozdov" class="text-blue-600 hover:underline">@igor.drozdov</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/stanhu" class="text-blue-600 hover:underline">@stanhu</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::create</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-07-28</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/static_reachability/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/static_reachability/_index.md
@@ -22,34 +22,7 @@ lastmod: "2026-02-09T20:42:10+00:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nilieskou" class="text-blue-600 hover:underline">@nilieskou</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/mbenayoun" class="text-blue-600 hover:underline">@mbenayoun</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/joelpatterson" class="text-blue-600 hover:underline">@joelpatterson</a>, <a href="https://gitlab.com/nilieskou" class="text-blue-600 hover:underline">@nilieskou</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::secure</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-10-01</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/tailwindcss/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/tailwindcss/_index.md
@@ -16,34 +16,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/peterhegman" class="text-blue-600 hover:underline">@peterhegman</a>, <a href="https://gitlab.com/svedova" class="text-blue-600 hover:underline">@svedova</a>, <a href="https://gitlab.com/pgascouvaillancourt" class="text-blue-600 hover:underline">@pgascouvaillancourt</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/samdbeckham" class="text-blue-600 hover:underline">@samdbeckham</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::manage</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-12-21</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/token_consolidation/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/token_consolidation/_index.md
@@ -25,34 +25,7 @@ lastmod: "2026-02-06T13:05:34+01:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ifarkas" class="text-blue-600 hover:underline">@ifarkas</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/hsutor" class="text-blue-600 hover:underline">@hsutor</a>, <a href="https://gitlab.com/adil.farrukh" class="text-blue-600 hover:underline">@adil.farrukh</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::software_supply_chain_security</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-02-23</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/track_vulns_across_branches/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/track_vulns_across_branches/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-10-30T10:25:15+00:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ghavenga" class="text-blue-600 hover:underline">@ghavenga</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/theoretick" class="text-blue-600 hover:underline">@theoretick</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~group::security_infrastructure</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-02-28</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/transfer_data/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/transfer_data/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-04-28T10:53:04-07:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/vyaklushin" class="text-blue-600 hover:underline">@vyaklushin</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a>, <a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ofernandez2" class="text-blue-600 hover:underline">@ofernandez2</a>, <a href="https://gitlab.com/sean_carroll" class="text-blue-600 hover:underline">@sean_carroll</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~group::source_code</span></td>
-<td class="px-3 py-2 border border-gray-300">2023-09-07</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/user_experience_slis/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/user_experience_slis/_index.md
@@ -20,34 +20,7 @@ lastmod: "2026-01-20T14:36:38+01:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">implemented</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/hmerscher" class="text-blue-600 hover:underline">@hmerscher</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/reprazent" class="text-blue-600 hover:underline">@reprazent</a>, <a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~team::Observability</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-02-03</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 用語集

--- a/content/handbook/engineering/architecture/design-documents/user_experience_slis/next_step.md
+++ b/content/handbook/engineering/architecture/design-documents/user_experience_slis/next_step.md
@@ -20,34 +20,7 @@ lastmod: "2025-10-24T17:11:31+02:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/hmerscher" class="text-blue-600 hover:underline">@hmerscher</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/reprazent" class="text-blue-600 hover:underline">@reprazent</a>, <a href="https://gitlab.com/andrewn" class="text-blue-600 hover:underline">@andrewn</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~team::Observability</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-03-24</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 動機

--- a/content/handbook/engineering/architecture/design-documents/work_item_rest_api/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/work_item_rest_api/_index.md
@@ -16,34 +16,7 @@ lastmod: "2026-02-10T10:24:36+01:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nicolasdular" class="text-blue-600 hover:underline">@nicolasdular</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ntepluhina" class="text-blue-600 hover:underline">@ntepluhina</a>, <a href="https://gitlab.com/engwan" class="text-blue-600 hover:underline">@engwan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/nicolasdular" class="text-blue-600 hover:underline">@nicolasdular</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::plan</span></td>
-<td class="px-3 py-2 border border-gray-300">2026-02-05</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/work_items/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/work_items/_index.md
@@ -17,34 +17,7 @@ lastmod: "2025-07-09T15:18:40+02:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">accepted</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ntepluhina" class="text-blue-600 hover:underline">@ntepluhina</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ayufan" class="text-blue-600 hover:underline">@ayufan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/gweaver" class="text-blue-600 hover:underline">@gweaver</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::plan</span></td>
-<td class="px-3 py-2 border border-gray-300">2022-09-28</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 このドキュメントは作成中です。いくつかの側面はまだ文書化されていませんが、将来追加する予定です。

--- a/content/handbook/engineering/architecture/design-documents/work_items_custom_fields/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/work_items_custom_fields/_index.md
@@ -22,34 +22,7 @@ lastmod: "2025-07-08T14:41:02+02:00"
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/fernanda.toledo" class="text-blue-600 hover:underline">@fernanda.toledo</a></td>
-<td class="px-3 py-2 border border-gray-300"></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/donaldcook" class="text-blue-600 hover:underline">@donaldcook</a>, <a href="https://gitlab.com/gweaver" class="text-blue-600 hover:underline">@gweaver</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::plan</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-05-13</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/work_items_custom_status/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/work_items_custom_status/_index.md
@@ -21,34 +21,7 @@ lastmod: "2025-11-06T10:01:09+01:00"
 
 <!-- This renders the design document header on the detail page, so don't remove it-->
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/msaleiko" class="text-blue-600 hover:underline">@msaleiko</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ntepluhina" class="text-blue-600 hover:underline">@ntepluhina</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/acroitor" class="text-blue-600 hover:underline">@acroitor</a>, <a href="https://gitlab.com/gweaver" class="text-blue-600 hover:underline">@gweaver</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::plan</span></td>
-<td class="px-3 py-2 border border-gray-300">2025-02-25</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/work_items_framework_vision/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/work_items_framework_vision/_index.md
@@ -17,34 +17,7 @@ lastmod: "2026-03-19T14:29:31+01:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">proposed</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/msaleiko" class="text-blue-600 hover:underline">@msaleiko</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/ntepluhina" class="text-blue-600 hover:underline">@ntepluhina</a>, <a href="https://gitlab.com/engwan" class="text-blue-600 hover:underline">@engwan</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/acroitor" class="text-blue-600 hover:underline">@acroitor</a>, <a href="https://gitlab.com/gweaver" class="text-blue-600 hover:underline">@gweaver</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::plan</span></td>
-<td class="px-3 py-2 border border-gray-300">2026-02-13</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## 概要

--- a/content/handbook/engineering/architecture/design-documents/workspaces/_index.md
+++ b/content/handbook/engineering/architecture/design-documents/workspaces/_index.md
@@ -18,34 +18,7 @@ lastmod: "2026-04-22T12:38:25+10:00"
 ---
 
 
-<div class="my-3 border-l-4 border-blue-500 bg-blue-50 px-4 py-3 rounded-r text-sm text-blue-800">
-このページには今後予定されている製品・機能・機能性に関する情報が含まれています。ここに示す情報は参考目的のみです。購入・計画の決定にこの情報を使用しないでください。製品・機能・機能性の開発、リリース、タイミングは変更または延期される可能性があり、GitLab Inc. の独自の判断に委ねられています。
-</div>
-
-<div class="overflow-x-auto my-4">
-<table class="w-full text-sm border-collapse">
-<thead>
-<tr class="bg-gray-100 text-left">
-<th class="px-3 py-2 border border-gray-300">Status</th>
-<th class="px-3 py-2 border border-gray-300">Authors</th>
-<th class="px-3 py-2 border border-gray-300">Coach</th>
-<th class="px-3 py-2 border border-gray-300">DRIs</th>
-<th class="px-3 py-2 border border-gray-300">Owning Stage</th>
-<th class="px-3 py-2 border border-gray-300">Created</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">ongoing</span></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/vtak" class="text-blue-600 hover:underline">@vtak</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/grzesiek" class="text-blue-600 hover:underline">@grzesiek</a></td>
-<td class="px-3 py-2 border border-gray-300"><a href="https://gitlab.com/michelle-chen" class="text-blue-600 hover:underline">@michelle-chen</a>, <a href="https://gitlab.com/adebayo_a" class="text-blue-600 hover:underline">@adebayo_a</a></td>
-<td class="px-3 py-2 border border-gray-300"><span class="inline-block rounded px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700">~devops::create</span></td>
-<td class="px-3 py-2 border border-gray-300">2022-11-15</td>
-</tr>
-</tbody>
-</table>
-</div>
+{{< engineering/design-document-header >}}
 
 
 ## はじめに


### PR DESCRIPTION
## Summary

PR #355 (1/2) と同じ趣旨。`engineering/architecture/design-documents/` 配下で `{{< engineering/design-document-header >}}` ショートコードが HTML 通知ブロック + ハードコード状態テーブルに事前展開されていた問題を upstream どおりに復元する 2 PR シリーズの後半。

## 対象

本 PR は **108 ファイル**（`git_data_offloading/_index.md` から `workspaces/_index.md` まで、アルファベット順後半）。前半は #355 を参照。

詳細な根拠・方法・対象外（`complex_spdx_expression_evaluation`）は #355 の説明を参照してください。

## Test plan

- [x] Hugo build 成功（ローカル、216 ファイル全件適用後 + 本 PR 単独の 108 ファイルでも確認）
- [ ] CI ビルド通過
- [ ] Codex レビュー対応（環境設定があれば）

🤖 Generated with [Claude Code](https://claude.com/claude-code)