### PR TITLE
fix(ci): tolerate 404 for release_post_managers.yml in upstream sync

### DIFF
--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -67,7 +67,18 @@ jobs:
         run: npm ci
 
       - name: Sync upstream public data (team.yml, tech_stack.yml, ...)
-        run: bash upstream/scripts/sync-data.sh
+        # Workaround: release_post_managers.yml was removed from
+        # www-gitlab-com (404) but is still listed in upstream/scripts/sync-data.sh.
+        # `set -eu` aborts the script on first download failure, so we strip the
+        # entry from the list and provide an empty stub for the
+        # release-post-scheduling shortcode (which ranges
+        # site.Data.public.release_post_managers.releases).
+        # Remove once upstream drops the reference.
+        run: |
+          sed -i '/release_post_managers\.yml/d' upstream/scripts/sync-data.sh
+          mkdir -p data/public
+          printf 'releases: []\n' > data/public/release_post_managers.yml
+          bash upstream/scripts/sync-data.sh
 
       - name: Hugo build
         run: hugo --logLevel error

--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -67,13 +67,14 @@ jobs:
         run: npm ci
 
       - name: Sync upstream public data (team.yml, tech_stack.yml, ...)
-        # Workaround: release_post_managers.yml was removed from
-        # www-gitlab-com (404) but is still listed in upstream/scripts/sync-data.sh.
-        # `set -eu` aborts the script on first download failure, so we strip the
-        # entry from the list and provide an empty stub for the
-        # release-post-scheduling shortcode (which ranges
-        # site.Data.public.release_post_managers.releases).
-        # Remove once upstream drops the reference.
+        # ワークアラウンド: release_post_managers.yml は www-gitlab-com から
+        # 削除されて 404 を返すようになったが、upstream/scripts/sync-data.sh の
+        # data_files にはまだ残っている。スクリプトは `set -eu` で走るため
+        # 最初の 404 で sync 全体が落ち、Hugo ビルドに到達できない。
+        # そこで対象エントリを sed で除外し、release-post-scheduling
+        # shortcode（site.Data.public.release_post_managers.releases を range
+        # する）が壊れないように空スタブを事前生成する。
+        # upstream が参照を消したら本ステップは元に戻すこと。
         run: |
           sed -i '/release_post_managers\.yml/d' upstream/scripts/sync-data.sh
           mkdir -p data/public

--- a/.github/workflows/app_deploy.yml
+++ b/.github/workflows/app_deploy.yml
@@ -55,13 +55,14 @@ jobs:
         # data/public/* を参照するページが多数あるため、upstream と同じ方式で
         # ビルド前に動的に取得する（git に入れない方針）。
         #
-        # Workaround: release_post_managers.yml was removed from
-        # www-gitlab-com (404) but is still listed in upstream/scripts/sync-data.sh.
-        # `set -eu` aborts the script on first download failure, so we strip the
-        # entry from the list and provide an empty stub for the
-        # release-post-scheduling shortcode (which ranges
-        # site.Data.public.release_post_managers.releases).
-        # Remove once upstream drops the reference.
+        # ワークアラウンド: release_post_managers.yml は www-gitlab-com から
+        # 削除されて 404 を返すようになったが、upstream/scripts/sync-data.sh の
+        # data_files にはまだ残っている。スクリプトは `set -eu` で走るため
+        # 最初の 404 で sync 全体が落ち、Hugo ビルドに到達できない。
+        # そこで対象エントリを sed で除外し、release-post-scheduling
+        # shortcode（site.Data.public.release_post_managers.releases を range
+        # する）が壊れないように空スタブを事前生成する。
+        # upstream が参照を消したら本ステップは元に戻すこと。
         run: |
           sed -i '/release_post_managers\.yml/d' upstream/scripts/sync-data.sh
           mkdir -p data/public

--- a/.github/workflows/app_deploy.yml
+++ b/.github/workflows/app_deploy.yml
@@ -54,7 +54,19 @@ jobs:
         # docsy-gitlab モジュールの content/handbook/company/team.md など、
         # data/public/* を参照するページが多数あるため、upstream と同じ方式で
         # ビルド前に動的に取得する（git に入れない方針）。
-        run: bash upstream/scripts/sync-data.sh
+        #
+        # Workaround: release_post_managers.yml was removed from
+        # www-gitlab-com (404) but is still listed in upstream/scripts/sync-data.sh.
+        # `set -eu` aborts the script on first download failure, so we strip the
+        # entry from the list and provide an empty stub for the
+        # release-post-scheduling shortcode (which ranges
+        # site.Data.public.release_post_managers.releases).
+        # Remove once upstream drops the reference.
+        run: |
+          sed -i '/release_post_managers\.yml/d' upstream/scripts/sync-data.sh
+          mkdir -p data/public
+          printf 'releases: []\n' > data/public/release_post_managers.yml
+          bash upstream/scripts/sync-data.sh
 
       - name: Hugo build
         run: hugo --minify


### PR DESCRIPTION
## Summary

- `upstream/scripts/sync-data.sh` lists `release_post_managers.yml` in its `data_files`, but that file has been removed from `www-gitlab-com` master and now returns **404**. Because the script runs under `set -eu` and `download()` exits 1 after 5 retries, the first 404 aborts the whole sync — Hugo never builds, and both PR CI (`app_ci.yml`) and the main deploy (`app_deploy.yml`) fail.
- Failing run (PR #367): https://github.com/kyama0/gitlab-handbook-ja/actions/runs/26326985984/job/77506408543
- This affects `main` too (same submodule pointer), so it is not specific to any translation PR.

## Fix

In both `app_ci.yml` and `app_deploy.yml`, before invoking `upstream/scripts/sync-data.sh`:

1. `sed` out the `release_post_managers.yml` entry from the script's `data_files` list.
2. Pre-create an empty stub `data/public/release_post_managers.yml` containing `releases: []` so the `release-post-scheduling` shortcode (which ranges `site.Data.public.release_post_managers.releases`) still renders.

The patch is intentionally scoped to one removed file with a comment to revert once upstream drops the reference.

## Verification

Locally in the worktree:

```
$ sed -i '/release_post_managers\.yml/d' upstream/scripts/sync-data.sh
$ mkdir -p data/public && printf 'releases: []\n' > data/public/release_post_managers.yml
$ bash upstream/scripts/sync-data.sh
... fetching all other files ...
=== SYNC COMPLETE ===
```

vs. unpatched:

```
fetching data/public/release_post_managers.yml ...
curl: (22) The requested URL returned error: 404
... 5 retries ...
ERROR: Failed to download ... after 5 attempts.
```

## Test plan

- [ ] App CI passes on this PR (Hugo Build green).
- [ ] After merge, the next deploy on `main` succeeds.
- [ ] Spot-check a page that uses the `release-post-scheduling` shortcode renders without template errors (the empty stub keeps it benign — the loop body just doesn't execute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)