### PR TITLE
fix: スマホで検索ダイアログが開かない問題を修正

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -71,6 +71,20 @@ h3 > a > sup {
 //     = slate-800) に合わせて上書き。
 // =====================================================================
 
+// navbar 側のトリガーボタンは lg 以上でのみ表示。lg 未満は sidebar 側の
+// 検索バーがすでに表示されているため二重に出さない。
+// (dialog 本体は navbar partial の中で render されるが、ラッパー
+//  .td-navbar__search は常に visible に保つ — display:none の親の中に
+//  dialog があると showModal() しても見えないため)
+.td-navbar .header-search-trigger {
+  display: none;
+}
+@media (min-width: 992px) {
+  .td-navbar .header-search-trigger {
+    display: inline-flex;
+  }
+}
+
 // ピル型のトリガーボタン (navbar 側 = dark bg、sidebar 側 = ライト bg
 // にも違和感ないよう半透明 currentColor を使う)
 .header-search-trigger {

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -81,7 +81,16 @@
       {{ end -}}
     </ul>
   </div>
-  <div class="d-none d-lg-block">
+  {{/*
+     検索 partial は `<dialog id="search-dialog">` 本体を初回呼び出し位置で
+     render する。以前はこの partial を `d-none d-lg-block` で囲っていたが、
+     その場合 lg 未満 (= スマホ・タブレット) では親要素が display: none となり、
+     sidebar 側のトリガーから window.__openSearchDialog() を呼んでも dialog 自体が
+     不可視親の中にあるため何も表示されない、という事象が発生した。
+     ここではラッパーから d-none を外し、navbar 側のトリガーボタンだけを CSS で
+     (.td-navbar .header-search-trigger) lg 未満では非表示にする。
+  */}}
+  <div class="td-navbar__search">
     {{ partial "search-input.html" . }}
   </div>
 </div>


### PR DESCRIPTION
## 概要

スマホ画面 (< 992px) でサイドバーの検索ボックスをタップしても何も起きない不具合を修正します。

## 原因

- `layouts/_partials/search-input.html` は、初回呼び出し位置 (`pagefindSearchIdNum == 1`) でのみ `<dialog id="search-dialog">` 本体を出力する設計
- その初回呼び出しは `layouts/_partials/navbar.html` 側で行われており、`<div class="d-none d-lg-block">` でラップされていた
- 結果として、lg 未満 (= スマホ・タブレット) では **dialog 本体の親要素が `display: none`** になり、サイドバー側トリガーから `window.__openSearchDialog()` → `dialog.showModal()` を呼んでもダイアログが見えない状態になっていた（祖先が display:none だと top layer に昇格しても可視化されない）

## 修正内容

- `layouts/_partials/navbar.html`: navbar 側 partial の親ラッパーから `d-none d-lg-block` を外して `td-navbar__search` に変更。dialog が常に visible な祖先の中に置かれることを保証する。次に触る人が同じ罠を踏まないよう経緯コメントも残した
- `assets/scss/_variables_project.scss`: navbar 側トリガーボタンだけを `.td-navbar .header-search-trigger` 経由で lg 未満では `display: none` に。サイドバー側ボタンとの二重表示は引き続き回避

## 動作確認

Playwright + Chromium で iPhone 13 サイズ (390x844) のビューポートで検証:

| 項目 | 修正前の挙動 | 修正後の実測 |
| --- | --- | --- |
| navbar 側トリガーの可視性 | 非表示 (d-none) | 非表示 (CSS で hide) ✓ |
| sidebar 側トリガーの可視性 | 表示 | 表示 ✓ |
| `<dialog>` の祖先 chain | `display: none` 含む | 全て `display: block/flex` ✓ |
| sidebar ボタンタップ後 `dialog.open` | (タップで何も起きない) | `true` ✓ |
| sidebar ボタンタップ後 `dialog.isVisible()` | false | `true` ✓ |

ローカル dev 環境では pagefind index 未生成のためダイアログ内に「`npm run pagefind` 実行後に利用できます」プレースホルダが出ますが、本番ビルドでは CI が pagefind を生成するため検索 UI が正常表示されます (今回の修正は dialog の可視性のみで pagefind 自体には触っていません)。

## Test plan

- [ ] スマホサイズ (< 992px) でサイドバーの検索ボックスをタップすると検索モーダルが開く
- [ ] デスクトップ (>= 992px) で navbar 側の検索ボタンが従来通り表示され、クリックで検索モーダルが開く
- [ ] デスクトップでサイドバー側の検索ボックスも従来通り動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)