### PR TITLE
translation: batch 2026-05-25-1 (sales-development, deployments-and-releases)

### DIFF
--- a/content/handbook/engineering/deployments-and-releases/_index.md
+++ b/content/handbook/engineering/deployments-and-releases/_index.md
@@ -1,11 +1,11 @@
 ---
 title: "デプロイメントとリリース"
 upstream_path: /handbook/engineering/deployments-and-releases/
-upstream_sha: 3480299851f7e2243d4f08b75dac452f89929636
-translated_at: "2026-04-28T04:23:44Z"
+upstream_sha: 7f50ef5c825dfb207a7a1e42224bbd3d77dc35cc
+translated_at: "2026-05-25T00:00:00Z"
 translator: claude
 stale: false
-lastmod: "2026-01-12T20:02:52-07:00"
+lastmod: "2026-05-25T12:15:55-06:00"
 ---
 
 ## 概要と用語
@@ -70,7 +70,7 @@ lastmod: "2026-01-12T20:02:52-07:00"
 1. [自動デプロイパッケージダッシュボード](https://dashboards.gitlab.net/d/delivery-auto_deploy_packages/delivery-auto-deploy-packages-information?orgId=1)のウォークスルー
 1. [DORA メトリクス分析ダッシュボード](https://gitlab.com/gitlab-org/gitlab/-/analytics/dashboards/dora_metrics?date_range_option=30d)の `Deployment frequency over time` および `Lead time for changes over time` パネルの月次ビューのウォークスルー — パターンや異常を確認します
 1. [デプロイメント SLO ダッシュボード](https://dashboards.gitlab.net/d/delivery-deployment_slo/delivery3a-deployment-slo)のウォークスルー — デプロイメント SLO とパッケージャーパイプライン期間
-1. [デプロイメントブロッカーダッシュボード](https://dashboards.gitlab.net/d/delivery-deployment_blockers/delivery3a-deployment-blockers?orgId=1&from=now-6d&to=now&timezone=utc&var-PROMETHEUS_DS=mimir-gitlab-ops&var-root_cause=$__all)および先週の[デプロイメントブロッカー](https://gitlab.com/groups/gitlab-com/gl-infra/-/epics/1496)のウォークスルー
+1. [デプロイメントブロッカーダッシュボード](https://dashboards.gitlab.net/d/delivery-deployment_blockers/delivery3a-deployment-blockers?orgId=1&from=now-6d&to=now&timezone=utc&var-PROMETHEUS_DS=mimir-gitlab-ops&var-root_cause=$__all)および先週の[デプロイメントブロッカー](https://gitlab.com/groups/gitlab-com/gl-infra/-/work_items/1822)のウォークスルー
 1. 先週の MTTP に基づいてアクションが必要かどうかの確認
 
 ### デプロイメントターゲット

--- a/content/handbook/marketing/sales-development/_index.md
+++ b/content/handbook/marketing/sales-development/_index.md
@@ -2,11 +2,11 @@
 title: セールス開発
 description: "このページの目的は、セールス開発組織のハンドブック上のホームページとして機能することです。"
 upstream_path: /handbook/marketing/sales-development/
-upstream_sha: 877082e5cd4baeabe3d6e802b3b4b1efdb6573f1
-translated_at: "2026-05-23T00:00:00Z"
+upstream_sha: 7f50ef5c825dfb207a7a1e42224bbd3d77dc35cc
+translated_at: "2026-05-25T00:00:00Z"
 translator: claude
 stale: false
-lastmod: "2026-05-22T15:06:37+00:00"
+lastmod: "2026-05-25T15:25:51+00:00"
 ---
 
 GitLab のセールス開発組織へようこそ！私たちは、インバウンドとアウトバウンドの両方の戦略を通じて[顧客のための結果](/handbook/values/#results)を促進するために設計されたチームです。私たちの構造は、アウトリーチ活動における効率性、応答性、創造性を最大化するように設計されています。
@@ -915,13 +915,33 @@ Outreach は、Sales および Sales Dev 向けのアウトバウンドエンゲ
 
 追加の Outreach 駆動の自動化（トリガー、ルールセット、シーケンス、レポート）については、メインの [Marketing Operations Outreach ページ](/handbook/marketing/marketing-operations/outreach/)を参照してください。
 
-### Claude
+### Claude Sales Dev BDR/SDR ユーザーガイド
 
-Claude は Anthropic の AI アシスタントです。調査、分析、コンテンツライティング、データ整理を支援できます。Claude は常に正しいわけではないことに注意してください — 間違っているときでも自信ありげに聞こえるので、使用する前に必ず出力を検証してください。
+[Claude Sales Dev BDR/SDR ガイダンススライド](https://docs.google.com/presentation/d/1ZwemeDll2Zz4nwhtIFD64edcQCJ6nFYHv6fOPPqV2Hs/edit)と [Claude Sales Dev 動画ウォークスルー](https://drive.google.com/file/d/1Gn6BjD6TfRNJ1eDGf3rAUJfA4g7LmCnd/view?usp=sharing)を参照してください。
 
-主要なリソース、プロジェクト、プロンプトライブラリへのリンクは、上記の [Claude Sales Dev BDR/SDR User Guide](/handbook/marketing/sales-development/#claude-sales-dev-bdrsdr-user-guide) セクションを参照してください。
+1. [プロンプトライブラリ](https://gitlab.com/gitlab-com/marketing/sales-development/-/issues/1231)
+1. [Business Development Prospecting Project](https://claude.ai/project/92974b9b-f70e-4d74-9288-20c443617e9c)
+1. [Sales Development Personalisation Project](https://claude.ai/project/019a15a5-c78c-71dc-8ce8-f68048ec8e63)
+1. [AMER Calling Analysis Project](https://claude.ai/project/0196022b-a414-7215-9cf0-22ec8e19f9aa)
+1. [EMEA Calling Analysis Project](https://claude.ai/project/01961368-cd7e-7652-a1e3-3d2427367998)
+
+成果やプロンプトは Slack の `#sales_dev_claude_insights` で共有してください。
 
 **制限事項:** Claude は GitLab システムや CRM データに直接アクセスできません。会話間で記憶を保持しません。[オレンジレベルまでのデータの共有が承認されています。](https://internal.gitlab.com/handbook/company/ai-at-gitlab/#5-what-type-of-data-is-okay-to-be-shared-with-claude)
+
+### RelevanceAI
+
+RelevanceAI は私たちの AI ワークフォースプラットフォームで、SDR および BDR チーム向けにリードのリサーチ、優先順位付け、重複排除を自動化するために使用されます。現在、2 つのエージェントが稼働しています。
+
+**Mona** は MQL リサーチアシスタントです。Salesforce でリードが MQL ステータスに到達すると、Mona は企業リサーチ、本人確認、購買シグナルのコンテキストを自動的にまとめ、傾向スコアと推奨される次のアクションをリードレコードに直接書き込みます。
+
+**Doope** は重複排除アシスタントです。一致するリードレコードとコンタクトレコードをチェックし、リサーチフィールドで競合をフラグ付けするとともに、重複レコードへのリンクを提示するため、担当者はシーケンス化の前にそれらを解消できます。
+
+#### RelevanceAI エージェントの使用
+
+**Relevance Priority** および **Relevance Next Action** フィールドは SDR の Z-lead ビューに表示され、個々のレコードを開かずにトリアージして対応できます。リードをクリックすると、本人確認の信頼度、企業コンテキスト、採用シグナル、評価の根拠を含む完全な **Relevance Research** フィールドを確認できます。**Relevance Summary** フィールドは、主要なフラグをコンパクトにまとめたものを提供し、すばやく参照できます。
+
+Mona の出力は担当者の判断の代わりにはなりません — 出発点として扱ってください。リサーチが不完全に見える場合や評価が適切でないと思われる場合は、**Relevance Last Updated** タイムスタンプを確認し、パターンがあれば Slack の `#sales-development-relevance-ai` で提起してください。
 
 ### ZoomInfo
 

--- a/translation-state/manifest.json
+++ b/translation-state/manifest.json
@@ -10570,11 +10570,11 @@
     },
     "content/handbook/engineering/deployments-and-releases/_index.md": {
       "path": "content/handbook/engineering/deployments-and-releases/_index.md",
-      "upstream_sha": "3480299851f7e2243d4f08b75dac452f89929636",
-      "translated_at": "2026-04-28T04:23:44Z",
-      "model": "claude-sonnet-4-6",
-      "input_hash": "fda19e1fbe99d060baa7993b36f31bd68307e9fa9a84dc5610320bf8334dbeda",
-      "upstream_committed_at": "2026-01-12T20:02:52-07:00"
+      "upstream_sha": "7f50ef5c825dfb207a7a1e42224bbd3d77dc35cc",
+      "translated_at": "2026-05-25T00:00:00Z",
+      "model": "claude-opus-4-7",
+      "input_hash": "66bcf28c31ce7a3aa82741f8be50d681402f99b6159d1c626588366173b08a54",
+      "upstream_committed_at": "2026-05-25T12:15:55-06:00"
     },
     "content/handbook/engineering/development/_index.md": {
       "path": "content/handbook/engineering/development/_index.md",
@@ -32650,11 +32650,11 @@
     },
     "content/handbook/marketing/sales-development/_index.md": {
       "path": "content/handbook/marketing/sales-development/_index.md",
-      "upstream_sha": "877082e5cd4baeabe3d6e802b3b4b1efdb6573f1",
-      "translated_at": "2026-05-23T00:00:00Z",
+      "upstream_sha": "7f50ef5c825dfb207a7a1e42224bbd3d77dc35cc",
+      "translated_at": "2026-05-25T00:00:00Z",
       "model": "claude-opus-4-7",
-      "input_hash": "4375046fd80a8c8f266ccb79d1af7b13aa4fdc672506c895af6696f56e8961a1",
-      "upstream_committed_at": "2026-05-22T15:06:37+00:00"
+      "input_hash": "02a78783a636538e2d1f2e195ce72e4aff4e2fa37843703874087bcafc875ac6",
+      "upstream_committed_at": "2026-05-25T15:25:51+00:00"
     },
     "content/handbook/marketing/sales-development/tanuki-tech.md": {
       "path": "content/handbook/marketing/sales-development/tanuki-tech.md",


### PR DESCRIPTION
## Summary
- 2 ファイル更新（いずれも upstream 追従 `[modified]`）
  - `marketing/sales-development/_index.md`: `### Claude` セクションを `### Claude Sales Dev BDR/SDR ユーザーガイド`（スライド/動画/プロジェクトリンク・プロンプトライブラリ）に拡充し、新規 `### RelevanceAI` セクション（Mona / Doope エージェント、Using RelevanceAI Agents）を追加
  - `engineering/deployments-and-releases/_index.md`: デプロイメントブロッカーリンクを `epics/1496` → `work_items/1822` に更新
- manifest entries 4119（変更なし、sha/lastmod/input_hash を 2 件 bump）
- upstream submodule を `7f50ef5` に更新
- base = `main`

## Test plan
- [x] manifest entries (4119) == content/ md ファイル数 (4118) + .html.md エイリアス 1
- [x] `npm run sync:upstream` の pending が空になることを確認
- [ ] hugo build は CI (app_ci.yml) に委譲（本環境に hugo 無し）
- [x] フロントマター追跡フィールド（upstream_sha / translated_at / lastmod / input_hash）更新確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9xhMiNEhmMzdABHfd3Dtp)_