### PR TITLE
translation: batch 2026-05-31-1 (developer-advocacy/content)

### DIFF
--- a/content/handbook/marketing/developer-relations/developer-advocacy/content.md
+++ b/content/handbook/marketing/developer-relations/developer-advocacy/content.md
@@ -2,11 +2,11 @@
 title: "デベロッパーアドボケイトのコンテンツライブラリとワークフロー"
 description: "デベロッパーアドボカシーチームのコンテンツライブラリ、コンテンツ作成と配信のワークフローについて学びます。"
 upstream_path: /handbook/marketing/developer-relations/developer-advocacy/content/
-upstream_sha: 1e195b58b9f249ff10bd0e705106c320fee86141
-translated_at: "2026-05-14T12:00:00Z"
+upstream_sha: 15baf9cba6d48a5e5ac2f021a8e0d467baa862f1
+translated_at: "2026-05-31T00:00:00Z"
 translator: claude
 stale: false
-lastmod: "2026-05-07T19:11:22+02:00"
+lastmod: "2026-05-28T17:02:01+09:00"
 ---
 
 デベロッパーアドボカシーチームは、キャンペーン、フィールドイネーブルメント、製品ローンチサポート、ユースケース採用、顧客向けデモ、一般的な学習・オンボーディングに使用できるコンテンツを作成しています。チームが参加するすべてのコンテンツとアクティビティは、[チームワークフロー](/handbook/marketing/developer-relations/developer-advocacy/workflow/) に従って Issue で追跡されます。
@@ -87,6 +87,7 @@ lastmod: "2026-05-07T19:11:22+02:00"
 
 | タイトル | 分野 | 最終更新 | DRI |
 |-------|------|--------------|-----|
+| [External agents - GitLab-managed - Japanese](https://gitlab.navattic.com/external-agents-managed-jp) | GitLab Duo Agent Platform | 2026-05-28 | @nakiyama-ext |
 | [GitLab Duo Agent Platform](https://dap-demo-hub-dac14a.gitlab.io/) | GitLab Duo Agent Platform | 2025-09-14 | @iganbaruch |
 | [GitLab MCP Server with Cursor - Japanese](https://gitlab.navattic.com/gitlab-mcp-server-jp) | GitLab Duo Agent Platform | 2025-12-10 | @nakiyama-ext |
 | [GitLab Duo Agent Platform - MCP - Japanese](https://gitlab.navattic.com/mcp-ja) | GitLab Duo Agent Platform | 2025-10-15 | @nakiyama-ext |

--- a/translation-state/manifest.json
+++ b/translation-state/manifest.json
@@ -18426,11 +18426,11 @@
     },
     "content/handbook/marketing/developer-relations/developer-advocacy/content.md": {
       "path": "content/handbook/marketing/developer-relations/developer-advocacy/content.md",
-      "upstream_sha": "1e195b58b9f249ff10bd0e705106c320fee86141",
-      "translated_at": "2026-05-14T12:00:00Z",
+      "upstream_sha": "15baf9cba6d48a5e5ac2f021a8e0d467baa862f1",
+      "translated_at": "2026-05-31T00:00:00Z",
       "model": "claude-opus-4-7",
-      "input_hash": "926a0ef4641877f7fd77780134ccf606a507b3140b2cf55d8ff26e9be6f15d46",
-      "upstream_committed_at": "2026-05-07T19:11:22+02:00"
+      "input_hash": "31892328b374a2c120fd1332443a6814cf9e26229388d69e19b5326a6605ce91",
+      "upstream_committed_at": "2026-05-28T17:02:01+09:00"
     },
     "content/handbook/marketing/developer-relations/developer-advocacy/dev-environments.md": {
       "path": "content/handbook/marketing/developer-relations/developer-advocacy/dev-environments.md",


### PR DESCRIPTION
## Summary
- 1 ファイル更新 (`content/handbook/marketing/developer-relations/developer-advocacy/content.md`)
- upstream `15baf9cba6` 追従: Centralized demo hub テーブルに 1 行追加 (External agents - GitLab-managed - Japanese)
- manifest entries 4124 → 4124 (1 entry 更新のみ、新規追加なし)
- base = `main`

## Test plan
- [x] manifest entries (4124) == content/ ファイル数 (4123) + .html.md エイリアス分 (1)
- [x] フロントマター追跡フィールド付与確認 (`upstream_sha`, `translated_at`, `lastmod`)
- [ ] hugo build は CI (app_ci.yml) で検証 (ローカルに hugo がない環境のため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011AHeGoCoYebvidrVmxBg6W)_