### PR TITLE
Enable Google Analytics (GA4) in production builds

### DIFF
--- a/.github/workflows/app_deploy.yml
+++ b/.github/workflows/app_deploy.yml
@@ -83,6 +83,18 @@ jobs:
           # されて効かないため。
           # https://gohugo.io/configuration/introduction/
           HUGO_PARAMS_imageBaseUrl: ${{ vars.PUBLIC_R2_BASE }}
+          # Google Analytics (GA4)。docsy の _partials/head.html が
+          # hugo.IsProduction のとき Hugo 組み込み partial "google_analytics.html"
+          # を呼び、それが services.googleAnalytics.id を読んで gtag を出力する。
+          # config.yaml には GA キーを置かず、本番ビルド時のみ env で注入する
+          # (ローカル hugo server は development 環境なので GA は出ない)。
+          # HUGO_SERVICES_GOOGLEANALYTICS_ID は `_` 区切りで
+          # services.googleanalytics.id に解決され、Hugo は config キーを
+          # 小文字化して照合するので camelCase の googleAnalytics と一致する。
+          # 測定 ID は client 側 HTML に露出する公開値 (infra/locals.tf の
+          # PUBLIC_GA4_ID と同値)。GitHub Actions Variable PUBLIC_GA4_ID が
+          # あればそれを使い、無ければリテラルにフォールバックする。
+          HUGO_SERVICES_GOOGLEANALYTICS_ID: ${{ vars.PUBLIC_GA4_ID || 'G-ED5RXHWDV6' }}
 
       - name: Pagefind index (CJK-aware static site search)
         run: npx pagefind --site public


### PR DESCRIPTION
## Summary
Adds Google Analytics (GA4) tracking to production builds by injecting the measurement ID via environment variable during the Hugo build process.

## Changes
- Added `HUGO_SERVICES_GOOGLEANALYTICS_ID` environment variable to the production build job in `.github/workflows/app_deploy.yml`
- The measurement ID is sourced from the GitHub Actions Variable `PUBLIC_GA4_ID` with a fallback to the literal value `G-ED5RXHWDV6`
- Leverages Hugo's built-in GA4 support: the docsy theme's `_partials/head.html` calls the `google_analytics.html` partial when `hugo.IsProduction` is true, which reads `services.googleAnalytics.id` and outputs the gtag script

## Implementation Details
- The GA4 measurement ID is a public value (exposed in client-side HTML) and matches the value in `infra/locals.tf` (`PUBLIC_GA4_ID`)
- Uses Hugo's environment variable override convention: `HUGO_SERVICES_GOOGLEANALYTICS_ID` (with `_` separators) resolves to `services.googleanalytics.id` in the config, which Hugo matches case-insensitively to `googleAnalytics`
- Local `hugo server` runs in development mode, so GA tracking will not be active locally
- The GA key is not stored in `config.yaml`; it is injected only during production builds for security

https://claude.ai/code/session_01V3cx2YJGuW1yKxzmzk6kof