### PR TITLE
glossary: add "hosted (リポジトリ種別) → ホスト型" entry

### DIFF
--- a/.claude/translation-glossary.md
+++ b/.claude/translation-glossary.md
@@ -46,6 +46,7 @@ GitLab Handbook 日本語訳の **唯一の用語集**。`.claude/agents/transla
 | feature | 機能 | 「フィーチャー」は不可（FX/SaaS 文脈の慣用は除く） |
 | feature flag | フィーチャーフラグ | `feature → 機能` の例外。業界標準訳語で handbook 全体で既に定着 |
 | Separation of Duty | 職務分掌 | 「職務分離」は不可（会計監査用語） |
+| hosted (リポジトリ種別) | ホスト型 | Artifact Registry のリポジトリ種別 hosted/virtual/remote の訳語統一。旧称 local も同じく「ホスト型」。種別以外の local（enforced locally など）は「ローカル」のまま |
 | material effect | 大きな影響 / 重要な影響 | 「物質的な影響」は不可（法務・財務文脈） |
 | force multiplier | フォース・マルチプライヤー（成果を何倍にも増幅させる存在） | 初出時に補足、以降は単に「フォース・マルチプライヤー」可 |
 | cost to serve | 提供コスト（cost to serve） | 初出時に英語併記推奨 |


### PR DESCRIPTION
## Summary
- `.claude/translation-glossary.md` に用語エントリ `hosted (リポジトリ種別) → ホスト型` を 1 件追加。
- Artifact Registry のリポジトリ種別 `hosted` / `virtual` / `remote` の訳語を統一するため。旧称 `local` も同じく「ホスト型」。種別以外の `local`（例: enforced locally）は「ローカル」のまま。

## Context
PR #400（翻訳バッチ 2026-06-11-1）のレビューで、`local → hosted` のリポジトリ種別変更に伴い訳語を統一しました。リポジトリの用語集メンテナンス規約（「用語集の変更は独立した PR / コミットにする」）に従い、翻訳バッチ本体（#400）から分離した専用 PR です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmfnmFnDCs9hm5Xf2KRmeJ)_